### PR TITLE
Edit CSV to allow install on OKD 3.11

### DIFF
--- a/olm/open-liberty-0.0.1.clusterserviceversion.yaml
+++ b/olm/open-liberty-0.0.1.clusterserviceversion.yaml
@@ -39,6 +39,7 @@ metadata:
        }
       }]
 spec:
+  minKubeVersion: 1.11.0
   displayName: Open Liberty Operator
   description: |
     Installs a Jakarta EE / MicroProfile / Spring application running on Open Liberty.  
@@ -79,7 +80,7 @@ spec:
       displayName: Open Liberty
       group: openliberty.io
       kind: OpenLiberty
-      name: openliberty.openliberty.io
+      name: openliberties.openliberty.io
       resources:
       - kind: Service
         name: ""
@@ -96,3 +97,111 @@ spec:
       - kind: ConfigMap
         version: v1
       version: v1alpha1
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: true
+    - type: MultiNamespace
+      supported: false
+    - type: AllNamespaces
+      supported: true
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+        - serviceAccountName: open-liberty-operator
+          rules:
+            - apiGroups:
+              - ""
+              resources:
+              - pods
+              - services
+              - endpoints
+              - persistentvolumeclaims
+              - events
+              - configmaps
+              - secrets
+              verbs:
+              - '*'
+            - apiGroups:
+              - ""
+              resources:
+              - namespaces
+              verbs:
+              - get
+            - apiGroups:
+              - apps
+              resources:
+              - deployments
+              - daemonsets
+              - replicasets
+              - statefulsets
+              verbs:
+              - '*'
+            - apiGroups:
+              - monitoring.coreos.com
+              resources:
+              - servicemonitors
+              verbs:
+              - get
+              - create
+            - apiGroups:
+              - apps
+              resourceNames:
+              - open-liberty-operator
+              resources:
+              - deployments/finalizers
+              verbs:
+              - update
+            - apiGroups:
+              - openliberty.io
+              resources:
+              - '*'
+              verbs:
+              - '*'
+      deployments:
+        - name: open-liberty-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: open-liberty-operator
+            template:
+              metadata:
+                labels:
+                  name: open-liberty-operator
+              spec:
+                serviceAccountName: open-liberty-operator
+                containers:
+                - name: open-liberty-operator
+                  image: openliberty/operator:0.0.1
+                  imagePullPolicy: Always
+                  env:
+                  - name: WATCH_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: OPERATOR_NAME
+                    value: "open-liberty-operator"
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                      - matchExpressions:
+                          - key: beta.kubernetes.io/arch
+                            operator: In
+                            values:
+                            - amd64
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 3
+                      preference:
+                        matchExpressions:
+                        - key: beta.kubernetes.io/arch
+                          operator: In
+                          values:
+                          - amd64


### PR DESCRIPTION
I modified the CSV to allow it to install on OKD 3.x.  I haven't tried to create an OpenLiberty object yet, but the operator starts up OK.

OKD required a minimum kubernetes version in the spec of the CSV.  I picked 1.11.0 since that's what I had, but, I suspect it can be lower than that.  I'm not sure how we test that part.  I remember reading somewhere that published operators should support at least 1.7.

The name 'openliberties.openliberty.io' needed to match the CRD.  I suspect that's why the operator "wasn't working" before the conversion to CSV.

The other sections (install, deployments, etc) were just missing and seemed like they were required based on other operators in the repository.  I used the values from the other .yaml files that we had, and just copied them into the CSV.