### PR TITLE
Updating Dockerfile to newer version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/helm-operator:v0.6.0
+FROM quay.io/operator-framework/helm-operator:v0.7.0
 
 COPY helm-charts/ ${HOME}/helm-charts/
 COPY watches.yaml ${HOME}/watches.yaml


### PR DESCRIPTION
The newest SDK uses a newer operator image