### PR TITLE
Sync up the CSV with the RBAC file

### DIFF
--- a/olm/open-liberty-0.0.1.clusterserviceversion.yaml
+++ b/olm/open-liberty-0.0.1.clusterserviceversion.yaml
@@ -126,6 +126,24 @@ spec:
               verbs:
               - '*'
             - apiGroups:
+              - "extensions"
+              resources:
+              - ingresses
+              verbs:
+              - '*'
+            - apiGroups:
+              - "autoscaling"
+              resources:
+              - horizontalpodautoscalers
+              verbs:
+              - '*'
+            - apiGroups:
+              - "batch"
+              resources:
+              - jobs
+              verbs:
+              - '*' 
+            - apiGroups:
               - ""
               resources:
               - namespaces


### PR DESCRIPTION
Fixes #14 
I compared the base set of roles with other operators in the community and it appears the permissions are consistent.  I would have thought less access would be required, but for example, the operator needs to create a deployment, as well as delete a deployment, as well as list the deployments so it can figure out if an appropriate deployment already exists.
I synced the RBAC permissions with the CSV permissions.  Some things were missing (ingress, batch, autoscaling).