### PR TITLE
Change the category to "Application Runtime"

### DIFF
--- a/olm/open-liberty.0.0.1.clusterserviceversion.yaml
+++ b/olm/open-liberty.0.0.1.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: placeholder
   annotations:
     capabilities: Seamless Upgrades
-    categories: "Integration & Delivery"
+    categories: "Application Runtime"
     certified: "false"
     containerImage: openliberty/operator:0.0.1
     createdAt: 2019-05-16T12:00:00.000-0500


### PR DESCRIPTION
It looks like there is a new category that is a better fit for us - Application Runtime.