### PR TITLE
Update app-deployment-sample.md

### DIFF
--- a/docs/app-deployment-sample.md
+++ b/docs/app-deployment-sample.md
@@ -38,7 +38,7 @@ The following commands shows how to build a docker image and how to push it to d
 
 * `git clone https://github.com/OpenLiberty/open-liberty-operator.git`
 * `cd open-liberty-operator`
-* `kubectl apply -f olm/open-liberty-crd.yaml`
+* `kubectl apply -f olm/open-liberty.crd.yaml`
 * `kubectl apply -f deploy/service_account.yaml`
 * `kubectl apply -f deploy/role.yaml`
 * `kubectl apply -f deploy/role_binding.yaml`


### PR DESCRIPTION
1. Updated name of the file to have . instead of -. When you clone the open-liberty-operator, file name is different than what is mentioned here.
``` 
ls -l  olm/
total 60
-rw-r--r--. 1 root root 35886 Aug  2 12:01 open-liberty.0.0.1.clusterserviceversion.yaml
-rw-r--r--. 1 root root 15282 Aug  2 12:01 open-liberty.crd.yaml
-rw-r--r--. 1 root root   104 Aug  2 12:01 open-liberty.package.yaml
```