### PR TITLE
Remove push stage from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ stages:
   - name: build
   - name: unit test
   - name: e2e test
-  - name: push
 
 jobs:
  include:
@@ -37,10 +36,3 @@ jobs:
     stage: e2e test
     script:
     - make test-e2e
-  - name: Push image
-    stage: push
-    script:
-    - make build-image
-    - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-    - make push-image
-    if: branch = master AND fork = false AND type != pull_request AND env(DOCKER_USERNAME) IS NOT blank AND env(DOCKER_PASSWORD) IS NOT blank


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Removes the push stage from travis
- Now that we're building multi-arch images from GHE we should no longer be pushing from this repo, as it will overwrite the manifest list that's now being created. 
