### PR TITLE
Modify user-guide to point to application-stacks

### DIFF
--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -85,8 +85,8 @@ Each `OpenLibertyApplication` CR must specify `applicationImage` parameter. Spec
 | `resourceConstraints.requests.memory` | The minimum memory in bytes. Specify integers with one of these suffixes: E, P, T, G, M, K, or power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.|
 | `resourceConstraints.limits.cpu` | The upper limit of CPU core. Specify integers, fractions (e.g. 0.5), or millicores values(e.g. 100m, where 100m is equivalent to .1 core). |
 | `resourceConstraints.limits.memory` | The memory upper limit in bytes. Specify integers with suffixes: E, P, T, G, M, K, or power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.|
-| `env`   | An array of environment variables following the format of `{name, value}`, where value is a simple string. |
-| `envFrom`   | An array of environment variables following the format of `{name, valueFrom}`, where `valueFrom` is YAML object containing a property named either `secretKeyRef` or `configMapKeyRef`, which in turn contain the properties `name` and `key`.|
+| `env`   | An array of environment variables following the format of `{name, value}`, where value is a simple string. It may also follow the format of `{name, valueFrom}`, where valueFrom refers to a value in a `ConfigMap` or `Secret` resource. See [Environment variables](https://github.com/application-stacks/operator/blob/master/doc/user-guide.md#environment-variables) for more info.|
+| `envFrom`   | An array of references to `ConfigMap` or `Secret` resources containing environment variables. Keys from `ConfigMap` or `Secret` resources become environment variable names in your container. See [Environment variables](https://github.com/application-stacks/operator/blob/master/doc/user-guide.md#environment-variables) for more info.|
 | `readinessProbe`   | A YAML object configuring the [Kubernetes readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-readiness-probes) that controls when the pod is ready to receive traffic. |
 | `livenessProbe` | A YAML object configuring the [Kubernetes liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-a-liveness-http-request) that controls when Kubernetes needs to restart the pod.|
 | `volumes` | A YAML object representing a [pod volume](https://kubernetes.io/docs/concepts/storage/volumes). |
@@ -123,82 +123,30 @@ oc get olapps my-liberty-app
 oc get openlibertyapplication my-liberty-app
 ```
 
-### Service account
+### Common Component Documentation
 
-The operator can create a `ServiceAccount` resource when deploying an Open Liberty application. If `serviceAccountName` is not specified in a CR, the operator creates a service account with the same name as the CR (e.g. `my-liberty-app`).
+Open Liberty Operator is based on the generic [Application Stacks
+Operator](https://github.com/application-stacks/operator). To see more
+information on the usage of common functionality, see Application Stacks
+documentation below. Note that, in the samples from the links below, the instances of `Kind:
+RuntimeComponent` must be replaced with `Kind: AppsodyApplication`.
 
-Users can also specify `serviceAccountName` when they want to create a service account manually.
+- [Image Streams](https://github.com/application-stacks/operator/blob/master/doc/user-guide.md#Image-streams)
+- [Service Account](https://github.com/application-stacks/operator/blob/master/doc/user-guide.md#Service-account)
+- [Labels](https://github.com/application-stacks/operator/blob/master/doc/user-guide.md#Labels)
+- [Annotations](https://github.com/application-stacks/operator/blob/master/doc/user-guide.md#Annotations)
+- [Environment Variables](https://github.com/application-stacks/operator/blob/master/doc/user-guide.md#Environment-variables)
+- [High Availability](https://github.com/application-stacks/operator/blob/master/doc/user-guide.md#High-availability)
+- [Persistence](https://github.com/application-stacks/operator/blob/master/doc/user-guide.md#Persistence)
+- [Service Binding](https://github.com/application-stacks/operator/blob/master/doc/user-guide.md#Service-binding)
+- [Monitoring](https://github.com/application-stacks/operator/blob/master/doc/user-guide.md#Monitoring)
+- [Knative Support](https://github.com/application-stacks/operator/blob/master/doc/user-guide.md#Knative-support)
+- [Exposing Service](https://github.com/application-stacks/operator/blob/master/doc/user-guide.md#Exposing-service-externally)
+- [Kubernetes Application Navigator](https://github.com/application-stacks/operator/blob/master/doc/user-guide.md#kubernetes-application-navigator-kappnav-support)
 
-If applications require specific permissions but still want the operator to create a `ServiceAccount`, users can still manually create a role binding to bind a role to the service account created by the operator. To learn more about Role-based access control (RBAC), see Kubernetes [documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
+For functionality that is unique to the Open Liberty Operator, see the following sections.
 
-### Labels
-
-By default, the operator adds the following labels into all resources created for an `OpenLibertyApplication` CR: `app.kubernetes.io/instance`, `app.kubernetes.io/name`, `app.kubernetes.io/managed-by`, `app.kubernetes.io/version` (when `version` is defined) and `stack.appsody.dev/id` (when `stack` is defined). You can set new labels in addition to the pre-existing ones or overwrite them, excluding the `app.kubernetes.io/instance` label. To set labels, specify them in your CR as key/value pairs.
-
-```yaml
-apiVersion: openliberty.io/v1beta1
-kind: OpenLibertyApplication
-metadata:
-  name: my-liberty-app
-  labels:
-    my-label-key: my-label-value
-spec:
-  applicationImage: quay.io/my-repo/my-app:1.0
-```
-
-_After the initial deployment of `OpenLibertyApplication`, any changes to its labels would be applied only when one of the parameters from `spec` is updated._
-
-### Annotations
-
-To add new annotations into all resources created for an `OpenLibertyApplication`, specify them in your CR as key/value pairs. Annotations specified in CR would override any annotations specified on a resource, except for the annotations set on `Service` using `service.annotations`.
-
-```yaml
-apiVersion: openliberty.io/v1beta1
-kind: OpenLibertyApplication
-metadata:
-  name: my-liberty-app
-  annotations:
-    my-annotation-key: my-annotation-value
-spec:
-  applicationImage: quay.io/my-repo/my-app:1.0
-```
-
-_After the initial deployment of `OpenLibertyApplication`, any changes to its annotations would be applied only when one of the parameters from `spec` is updated._
-
-### Environment variables
-
-You can set environment variables for your application container. To set environment variables, specify `env` and/or `envFrom` fields in your CR. The environment variables can come directly from key/value pairs, `ConfigMap`s or `Secret`s.
-
- ```yaml
-apiVersion: openliberty.io/v1beta1
-kind: OpenLibertyApplication
-metadata:
-  name: my-liberty-app
-spec:
-  applicationImage: quay.io/my-repo/my-app:1.0
-  env:
-    - name: DB_PORT
-      value: "6379"
-    - name: DB_USERNAME
-      valueFrom:
-        secretKeyRef:
-          name: db-credential
-          key: adminUsername
-    - name: DB_PASSWORD
-      valueFrom:
-        secretKeyRef:
-          name: db-credential
-          key: adminPassword
-  envFrom:
-    - configMapRef:
-        name: env-configmap
-    - secretRef:
-        name: env-secrets
-```
-
-Use `envFrom` to define all data in a `ConfigMap` or a `Secret` as environment variables in a container. Keys from `ConfigMap` or `Secret` resources become environment variable name in your container.
-
-#### Console Logging Variables
+### Open Liberty Environment Variables
 
 The Open Liberty Operator sets a number of environment variables related to console logging by default. The following table shows the variables and their corresponding values.
 
@@ -226,270 +174,37 @@ spec:
       value: "error"
 ```
 
-
-### High availability
-
-Run multiple instances of your application for high availability using one of the following mechanisms: 
- - specify a static number of instances to run at all times using `replicas` parameter
- 
-    _OR_
-
- - configure auto-scaling to create (and delete) instances based on resource consumption using the `autoscaling` parameter.
-      - Parameters `autoscaling.maxReplicas` and `resourceConstraints.requests.cpu` MUST be specified for auto-scaling.
-
-### Persistence
-
-Open Liberty Operator is capable of creating a `StatefulSet` and `PersistentVolumeClaim` for each pod if `storage` is specified in the `OpenLibertyApplication` CR.
-
-Users also can provide mount points for their application. There are 2 ways to enable storage.
-
-#### Basic storage
-
-With the `OpenLibertyApplication` CR definition below the operator will create `PersistentVolumeClaim` called `pvc` with the size of `1Gi` and `ReadWriteOnce` access mode.
-
-The operator will also create a volume mount for the `StatefulSet` mounting to `/data` folder. You can use `volumeMounts` field instead of `storage.mountPath` if you require to persist more then one folder.
-
-```yaml
-apiVersion: openliberty.io/v1beta1
-kind: OpenLibertyApplication
-metadata:
-  name: my-liberty-app
-spec:
-  applicationImage: quay.io/my-repo/my-app:1.0
-  storage:
-    size: 1Gi
-    mountPath: "/data"
-```
-
-#### Advanced storage
-
-Open Liberty Operator allows users to provide entire `volumeClaimTemplate` for full control over automatically created `PersistentVolumeClaim`.
-
-It is also possible to create multiple volume mount points for persistent volume using `volumeMounts` field as shown below. You can still use `storage.mountPath` if you require only a single mount point.
-
-```yaml
-apiVersion: openliberty.io/v1beta1
-kind: OpenLibertyApplication
-metadata:
-  name: my-liberty-app
-spec:
-  applicationImage: quay.io/my-repo/my-app:1.0
-  volumeMounts:
-  - name: pvc
-    mountPath: /data_1
-    subPath: data_1
-  - name: pvc
-    mountPath: /data_2
-    subPath: data_2
-  storage:
-    volumeClaimTemplate:
-      metadata:
-        name: pvc
-      spec:
-        accessModes:
-        - "ReadWriteMany"
-        storageClassName: 'glusterfs'
-        resources:
-          requests:
-            storage: 1Gi
-```
-
-#### Storage for serviceability
+### Storage for serviceability
 
 The operator makes it easy to use a single storage for serviceability related operations, such as gatherig server traces or dumps (see [Day-2 Operations](#day-2-operations)). The single storage will be shared by all Pods of an `OpenLibertyApplication` instance. This way you don't need to mount a separate storage for each Pod. Your cluster must be configured to automatically bind the `PersistentVolumeClaim` (PVC) to a `PersistentVolume` or you must bind it manually.
 
 You can specify the size of the persisted storage to request using `serviceability.size` parameter. The operator will automatically create a `PersistentVolumeClaim` with the specified size and access modes `ReadWriteMany` and `ReadWriteOnce`. It will be mounted at `/serviceability` inside all Pods of the `OpenLibertyApplication` instance.
 
+```yaml
+apiVersion: openliberty.io/v1beta1
+kind: OpenLibertyApplication
+metadata:
+  name: my-liberty-app
+spec:
+  applicationImage: quay.io/my-repo/my-app:1.0
+  serviceability:
+    size: 1Gi
+```
+
 You can also create the `PersistentVolumeClaim` yourself and specify its name using `serviceability.volumeClaimName` parameter. You must create it in the same namespace as the `OpenLibertyApplication` instance.
 
+```yaml
+apiVersion: openliberty.io/v1beta1
+kind: OpenLibertyApplication
+metadata:
+  name: my-liberty-app
+spec:
+  applicationImage: quay.io/my-repo/my-app:1.0
+  serviceability:
+    volumeClaimName: my-pvc
+```
+
 _Once a `PersistentVolumeClaim` is created by operator, its size can not be updated. It will not be deleted when serviceability is disabled or when the `OpenLibertyApplication` is deleted._
-
-### Service binding
-
-Open Liberty Operator can be used to help with service binding in a cluster. The operator creates a secret on behalf of the **provider** `OpenLibertyApplication` and injects the secret into pods of the **consumer** `OpenLibertyApplication` as either environment variable or mounted files. See [Design for Service Binding](https://docs.google.com/document/d/1riOX0iTnBBJpTKAHcQShYVMlgkaTNKb4m8fY7W1GqMA/edit) for more information on the architecture. At this time, the only supported service binding type is `openapi`.
-
-The provider lists information about the REST API it provides:
-
-```yaml
-apiVersion: openliberty.io/v1beta1
-kind: OpenLibertyApplication
-metadata:
-  name: my-provider
-  namespace: pro-namespace
-spec:
-  applicationImage: quay.io/my-repo/my-provider:1.0
-  service:
-    port: 3000
-    provides:
-      category: openapi
-      context: /my-context
-      auth:
-        password:
-          name: my-secret
-          key: password
-        username:
-          name: my-secret
-          key: username
----
-kind: Secret
-apiVersion: v1
-metadata:
-  name: my-secret
-  namespace: pro-namespace
-data:
-  password: bW9vb29vb28=
-  username: dGhlbGF1Z2hpbmdjb3c=
-type: Opaque
-```
-
-And the consumer lists the services it is intending to consume:
-
-```yaml
-apiVersion: openliberty.io/v1beta1
-kind: OpenLibertyApplication
-metadata:
-  name: my-consumer
-  namespace: con-namespace
-spec:
-  applicationImage: quay.io/my-repo/my-consumer:1.0
-  expose: true
-  service:
-    port: 9080
-    consumes:
-    - category: openapi
-      name: my-provider
-      namespace: pro-namespace
-      mountPath: /liberty
-```
-
-In the above example, the operator creates a secret named `pro-namespace-my-provider` and adds the following key-value pairs: `username`, `password`, `url`, `context`, `protocol` and `hostname`. The `url` value format is `<protocol>://<name>.<namespace>.svc.cluster.local:<port>/<context>`. Since the provider and the consumer are in two different namespaces, the operator copies the provider secret into consumer's namespace. The operator then mounts the provider secret into a directory with the pattern `<mountPath>/<namespace>/<service_name>` on application container within pods. In the above example, the secret will be serialized into `/liberty/pro-namespace/my-provider`, which means we will have a file for each key, where the filename is the key and the content is the key's value.
-
-If consumer's CR does not include `mountPath`, the secret will be bound to environment variables with the pattern `<NAMESPACE>_<SERVICE-NAME>_<KEY>`, and the value of that env var is the key’s value. Due to syntax restrictions for Kubernetes environment variables, the string representing the namespace and the string representing the service name will have to be normalized by turning any non-`[azAZ09]` characters to become an underscore `(_)` character.
-
-### Monitoring
-
-Open Liberty Operator can create a `ServiceMonitor` resource to integrate with `Prometheus Operator`.
-
-_This feature does not support integration with Knative Service. Prometheus Operator is required to use ServiceMonitor._
-
-#### Basic monitoring specification
-
-At minimum, a label needs to be provided that Prometheus expects to be set on `ServiceMonitor` objects. In this case, it is `apps-prometheus`.
-
-```yaml
-apiVersion: openliberty.io/v1beta1
-kind: OpenLibertyApplication
-metadata:
-  name: my-liberty-app
-spec:
-  applicationImage: quay.io/my-repo/my-app:1.0
-  monitoring:
-    labels:
-       apps-prometheus: ''
-```
-
-#### Advanced monitoring specification
-
-For advanced scenarios, it is possible to set many `ServicerMonitor` settings such as authentication secret using [Prometheus Endpoint](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint)
-
-```yaml
-apiVersion: openliberty.io/v1beta1
-kind: OpenLibertyApplication
-metadata:
-  name: my-liberty-app
-spec:
-  applicationImage: quay.io/my-repo/my-app:1.0
-  monitoring:
-    labels:
-       app-prometheus: ''
-    endpoints:
-    - interval: '30s'
-      basicAuth:
-        username:
-          key: username
-          name: metrics-secret
-        password:
-          key: password
-          name: metrics-secret
-      tlsConfig:
-        insecureSkipVerify: true
-```
-
-### Knative support
-
-Open Liberty Operator can deploy serverless applications with [Knative](https://knative.dev/docs/) on a Kubernetes cluster. To achieve this, the operator creates a [Knative `Service`](https://github.com/knative/serving/blob/master/docs/spec/spec.md#service) resource which manages the whole life cycle of a workload.
-
-To create Knative service, set `createKnativeService` to `true`:
-
-```yaml
-apiVersion: openliberty.io/v1beta1
-kind: OpenLibertyApplication
-metadata:
-  name: my-liberty-app
-spec:
-  applicationImage: quay.io/my-repo/my-app:1.0
-  createKnativeService: true
-```
-
-By setting this parameter, the operator creates a Knative service in the cluster and populates the resource with applicable `OpenLibertyApplication` fields. Also, it ensures non-Knative resources including Kubernetes `Service`, `Route`, `Deployment` and etc. are deleted.
-
-The CRD fields which are used to populate the Knative service resource include `applicationImage`, `serviceAccountName`, `livenessProbe`, `readinessProbe`, `service.Port`, `volumes`, `volumeMounts`, `env`, `envFrom`, `pullSecret` and `pullPolicy`.
-
-For more details on how to configure Knative for tasks such as enabling HTTPS connections and setting up a custom domain, checkout [Knative Documentation](https://knative.dev/docs/serving/).
-
-_Autoscaling related fields in `OpenLibertyApplication` are not used to configure Knative Pod Autoscaler (KPA). To learn more about how to configure KPA, see [Configuring the Autoscaler](https://knative.dev/docs/serving/configuring-the-autoscaler/)._
-
-_This feature is only available if you have Knative installed on your cluster._
-
-### Exposing service externally
-
-#### Non-Knative deployment
-
-To expose your application externally, set `expose` to `true`:
-
-```yaml
-apiVersion: openliberty.io/v1beta1
-kind: OpenLibertyApplication
-metadata:
-  name: my-liberty-app
-spec:
-  applicationImage: quay.io/my-repo/my-app:1.0
-  expose: true
-```
-
-By setting this parameter, the operator creates an unsecured route based on your application service. Setting this parameter is same as running `oc expose service <service-name>`.
-
-To create a secured HTTPS route, see [secured routes](https://docs.openshift.com/container-platform/3.11/architecture/networking/routes.html#secured-routes) for more information.
-
-_This feature is only available if you are running on OKD or OpenShift._
-
-#### Knative deployment
-
-To expose your application as a Knative service externally, set `expose` to `true`:
-
-```yaml
-apiVersion: openliberty.io/v1beta1
-kind: OpenLibertyApplication
-metadata:
-  name: my-liberty-app
-spec:
-  applicationImage: quay.io/my-repo/my-app:1.0
-  createKnativeService: true
-  expose: true
-```
-
-When `expose` is **not** set to `true`, the Knative service is labeled with `serving.knative.dev/visibility=cluster-local` which makes the Knative route to only be available on the cluster-local network (and not on the public Internet). However, if `expose` is set `true`, the Knative route would be accessible externally.
-
-To configure secure HTTPS connections for your deployment, see [Configuring HTTPS with TLS certificates](https://knative.dev/docs/serving/using-a-tls-cert/) for more information.
-
-
-### Kubernetes Application Navigator (kAppNav) support
-
-By default, Open Liberty Operator configures the Kubernetes resources it generates to allow automatic creation of an application definition by [kAppNav](https://kappnav.io/), Kubernetes Application Navigator. You can easily view and manage the deployed resources that comprise your application using Application Navigator. You can disable auto-creation by setting `createAppDefinition` to `false`.
-
-To join an existing application definition, disable auto-creation and set the label(s) needed to join the application on `OpenLibertyApplication` CR. See [Labels](#labels) section for more information.
-
-_This feature is only available if you have kAppNav installed on your cluster. Auto creation of an application definition is not supported when Knative service is created_
 
 ### Troubleshooting
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -58,7 +58,6 @@ Each `OpenLibertyApplication` CR must specify `applicationImage` parameter. Spec
 | `pullPolicy` | The policy used when pulling the image.  One of: `Always`, `Never`, and `IfNotPresent`. |
 | `pullSecret` | If using a registry that requires authentication, the name of the secret containing credentials. |
 | `version` | The current version of the application. Label `app.kubernetes.io/version` will be added to all resources when the version is defined. |
-| `stack` | Optional. The name of the [Appsody application stack](https://github.com/appsody/stacks) that produced this application image. |
 | `serviceAccountName` | The name of the OpenShift service account to be used during deployment. |
 | `initContainers` | The list of [Init Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#container-v1-core) definitions. |
 | `architecture` | An array of architectures to be considered for deployment. Their position in the array indicates preference. |
@@ -129,7 +128,7 @@ Open Liberty Operator is based on the generic [Application Stacks
 Operator](https://github.com/application-stacks/operator). To see more
 information on the usage of common functionality, see Application Stacks
 documentation below. Note that, in the samples from the links below, the instances of `Kind:
-RuntimeComponent` must be replaced with `Kind: AppsodyApplication`.
+RuntimeComponent` must be replaced with `Kind: OpenLibertyApplication`.
 
 - [Image Streams](https://github.com/application-stacks/operator/blob/master/doc/user-guide.md#Image-streams)
 - [Service Account](https://github.com/application-stacks/operator/blob/master/doc/user-guide.md#Service-account)


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Where applicable point to the generic operator, and modify existing
docs to better document that relationship.
- Update the serviceability documentation to include example usage and separate it from the generic operator documentation.
-  Copy over updates to `env` and `envFrom` field descriptions in the CR field table from [appsody](https://github.com/appsody/appsody-operator/pull/216).
- Removed the `stack` field description from the table, as I don't believe it's supposed to be there.

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #107 
