### PR TITLE
Update autoscaling e2e test

### DIFF
--- a/scripts/build-releases.sh
+++ b/scripts/build-releases.sh
@@ -51,6 +51,7 @@ main() {
   push_release "daily"
 
   ## loop through tagged releases and build
+  git fetch origin
   local tags=$(git tag -l)
   while read -r tag; do
     if [[ -z "${tag}" ]]; then
@@ -73,7 +74,7 @@ main() {
   done <<< "${tags}"
 
   echo "****** Complete!"
-  git checkout -q "master"
+  git checkout "${TRAVIS_BRANCH}"
 }
 
 build_release() {

--- a/test/e2e/openliberty_autoscaling.go
+++ b/test/e2e/openliberty_autoscaling.go
@@ -32,6 +32,7 @@ func OpenLibertyAutoScalingTest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get namespace: %v", err)
 	}
+	const name string = "example-liberty-autoscaling"
 
 	// Wait for the operator as the following configmaps won't exist until it has deployed
 	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, "open-liberty-operator", 1, retryInterval, operatorTimeout)
@@ -45,12 +46,12 @@ func OpenLibertyAutoScalingTest(t *testing.T) {
 	// create one replica of the operator deployment in current namespace with provided name
 	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, "open-liberty-operator", 1, retryInterval, operatorTimeout)
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	// Make basic open liberty application with 1 replica
 	replicas := int32(1)
-	openLibertyApplication := util.MakeBasicOpenLibertyApplication(t, f, "example-liberty-autoscaling", namespace, replicas)
+	openLibertyApplication := util.MakeBasicOpenLibertyApplication(t, f, name, namespace, replicas)
 
 	// use TestCtx's create helper to create the object and add a cleanup function for the new object
 	err = f.Client.Create(goctx.TODO(), openLibertyApplication, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
@@ -59,31 +60,27 @@ func OpenLibertyAutoScalingTest(t *testing.T) {
 	}
 
 	// wait for example-liberty-autoscaling to reach 1 replicas
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "example-liberty-autoscaling", 1, retryInterval, timeout)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, name, 1, retryInterval, timeout)
+	if err != nil {
+		util.FailureCleanup(t, f, namespace, err)
+	}
+
+	target := types.NamespacedName{Name: name, Namespace: namespace}
+	err = util.UpdateApplication(f, target, func(o *openlibertyv1beta1.OpenLibertyApplication) {
+		o.Spec.ResourceConstraints = setResources("0.2")
+		o.Spec.Autoscaling = setAutoScale(5, 50)
+	})
 	if err != nil {
 		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	// Check the name field that matches
-	m := map[string]string{"metadata.name": "example-liberty-autoscaling"}
+	m := map[string]string{"metadata.name": name}
 	l := fields.Set(m)
 	selec := l.AsSelector()
 
-	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: "example-liberty-autoscaling", Namespace: namespace}, openLibertyApplication)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	openLibertyApplication.Spec.ResourceConstraints = setResources("0.2")
-	openLibertyApplication.Spec.Autoscaling = setAutoScale(5, 50)
-
-	err = f.Client.Update(goctx.TODO(), openLibertyApplication)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	hpa := &autoscalingv1.HorizontalPodAutoscalerList{}
-	options := k.ListOptions{FieldSelector: selec}
+	options := k.ListOptions{FieldSelector: selec, Namespace: namespace}
 	hpa = getHPA(hpa, t, f, options)
 
 	timestamp = time.Now().UTC()
@@ -91,13 +88,14 @@ func OpenLibertyAutoScalingTest(t *testing.T) {
 
 	err = waitForHPA(hpa, t, 1, 5, 50, f, options)
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	updateTest(t, f, openLibertyApplication, options, namespace, hpa)
 	minMaxTest(t, f, openLibertyApplication, options, namespace, hpa)
 	minBoundaryTest(t, f, openLibertyApplication, options, namespace, hpa)
 	incorrectFieldsTest(t, f, ctx)
+	replicasTest(t, f, ctx)
 }
 
 func getHPA(hpa *autoscalingv1.HorizontalPodAutoscalerList, t *testing.T, f *framework.Framework, options k.ListOptions) *autoscalingv1.HorizontalPodAutoscalerList {
@@ -116,7 +114,6 @@ func waitForHPA(hpa *autoscalingv1.HorizontalPodAutoscalerList, t *testing.T, mi
 		}
 	}
 	return checkValues(hpa, t, minReplicas, maxReplicas, utiliz)
-
 }
 
 func setResources(cpu string) *corev1.ResourceRequirements {
@@ -172,7 +169,7 @@ func updateTest(t *testing.T, f *framework.Framework, openLibertyApplication *op
 
 	err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: "example-liberty-autoscaling", Namespace: namespace}, openLibertyApplication)
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	openLibertyApplication.Spec.ResourceConstraints = setResources("0.2")
@@ -180,7 +177,7 @@ func updateTest(t *testing.T, f *framework.Framework, openLibertyApplication *op
 
 	err = f.Client.Update(goctx.TODO(), openLibertyApplication)
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	timestamp := time.Now().UTC()
@@ -190,7 +187,7 @@ func updateTest(t *testing.T, f *framework.Framework, openLibertyApplication *op
 
 	err = waitForHPA(hpa, t, 2, 3, 30, f, options)
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 }
 
@@ -199,7 +196,7 @@ func minMaxTest(t *testing.T, f *framework.Framework, openLibertyApplication *op
 
 	err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: "example-liberty-autoscaling", Namespace: namespace}, openLibertyApplication)
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	openLibertyApplication.Spec.ResourceConstraints = setResources("0.2")
@@ -207,7 +204,7 @@ func minMaxTest(t *testing.T, f *framework.Framework, openLibertyApplication *op
 
 	err = f.Client.Update(goctx.TODO(), openLibertyApplication)
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	timestamp := time.Now().UTC()
@@ -217,7 +214,7 @@ func minMaxTest(t *testing.T, f *framework.Framework, openLibertyApplication *op
 
 	err = waitForHPA(hpa, t, 2, 3, 30, f, options)
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 }
 
@@ -226,7 +223,7 @@ func minBoundaryTest(t *testing.T, f *framework.Framework, openLibertyApplicatio
 
 	err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: "example-liberty-autoscaling", Namespace: namespace}, openLibertyApplication)
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	openLibertyApplication.Spec.ResourceConstraints = setResources("0.5")
@@ -234,7 +231,7 @@ func minBoundaryTest(t *testing.T, f *framework.Framework, openLibertyApplicatio
 
 	err = f.Client.Update(goctx.TODO(), openLibertyApplication)
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	timestamp := time.Now().UTC()
@@ -244,7 +241,7 @@ func minBoundaryTest(t *testing.T, f *framework.Framework, openLibertyApplicatio
 
 	err = waitForHPA(hpa, t, 2, 3, 30, f, options)
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 }
 
@@ -255,36 +252,37 @@ func incorrectFieldsTest(t *testing.T, f *framework.Framework, ctx *framework.Te
 	if err != nil {
 		t.Fatalf("could not get namespace: %v", err)
 	}
+	const name string = "example-liberty-autoscaling2"
 
 	timestamp := time.Now().UTC()
 	t.Logf("%s - Starting liberty autoscaling test...", timestamp)
 
 	// Make basic liberty application with 1 replica
 	replicas := int32(1)
-	openLibertyApplication := util.MakeBasicOpenLibertyApplication(t, f, "example-liberty-autoscaling2", namespace, replicas)
+	openLibertyApplication := util.MakeBasicOpenLibertyApplication(t, f, name, namespace, replicas)
 
 	// use TestCtx's create helper to create the object and add a cleanup function for the new object
 	err = f.Client.Create(goctx.TODO(), openLibertyApplication, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	// wait for example-liberty-autoscaling to reach 1 replicas
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "example-liberty-autoscaling2", 1, retryInterval, timeout)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, name, 1, retryInterval, timeout)
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	// Check the name field that matches
-	m := map[string]string{"metadata.name": "example-liberty-autoscaling2"}
+	m := map[string]string{"metadata.name": name}
 	l := fields.Set(m)
 	selec := l.AsSelector()
 
-	options := k.ListOptions{FieldSelector: selec}
+	options := k.ListOptions{FieldSelector: selec, Namespace: namespace}
 
-	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: "example-liberty-autoscaling2", Namespace: namespace}, openLibertyApplication)
+	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, openLibertyApplication)
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	openLibertyApplication.Spec.ResourceConstraints = setResources("0.3")
@@ -292,7 +290,7 @@ func incorrectFieldsTest(t *testing.T, f *framework.Framework, ctx *framework.Te
 
 	err = f.Client.Update(goctx.TODO(), openLibertyApplication)
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	timestamp = time.Now().UTC()
@@ -305,5 +303,65 @@ func incorrectFieldsTest(t *testing.T, f *framework.Framework, ctx *framework.Te
 		t.Log("The mandatory fields were not set so autoscaling is not enabled")
 	} else {
 		t.Fatal("Error: The mandatory fields were not set so autoscaling should not be enabled")
+	}
+}
+
+func replicasTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) {
+	const name = "liberty-autoscaling-replicas"
+	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		t.Fatalf("could not get namespace: %v", err)
+	}
+
+	timestamp := time.Now().UTC()
+	t.Logf("%s - Starting runtime autoscaling test...", timestamp)
+
+	// Make basic runtime omponent with 1 replica
+	replicas := int32(2)
+	runtime := util.MakeBasicOpenLibertyApplication(t, f, name, namespace, replicas)
+
+	err = f.Client.Create(goctx.TODO(), runtime, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	if err != nil {
+		util.FailureCleanup(t, f, namespace, err)
+	}
+
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, name, int(replicas), retryInterval, timeout)
+	if err != nil {
+		util.FailureCleanup(t, f, namespace, err)
+	}
+
+	// check that it prioritizes the HPA's minimum number of replicas over spec replicas
+	target := types.NamespacedName{Namespace: namespace, Name: name}
+	err = util.UpdateApplication(f, target, func(o *openlibertyv1beta1.OpenLibertyApplication) {
+		o.Spec.ResourceConstraints = setResources("0.5")
+		var cpu int32 = 50
+		var min int32 = 3
+		o.Spec.Autoscaling = &openlibertyv1beta1.OpenLibertyApplicationAutoScaling{
+			TargetCPUUtilizationPercentage: &cpu,
+			MaxReplicas:                    5,
+			MinReplicas:                    &min,
+		}
+	})
+	if err != nil {
+		util.FailureCleanup(t, f, namespace, err)
+	}
+
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, name, 3, retryInterval, timeout)
+	if err != nil {
+		util.FailureCleanup(t, f, namespace, err)
+	}
+
+	// check that it correctly returns to defined replica count after deleting HPA
+	err = util.UpdateApplication(f, target, func(o *openlibertyv1beta1.OpenLibertyApplication) {
+		o.Spec.ResourceConstraints = nil
+		o.Spec.Autoscaling = nil
+	})
+	if err != nil {
+		util.FailureCleanup(t, f, namespace, err)
+	}
+
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, name, int(replicas), retryInterval, timeout)
+	if err != nil {
+		util.FailureCleanup(t, f, namespace, err)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Ports updates to the autoscaling from runtime component operator e2e tests
- Fix multiarch build-releases.sh script

