### PR TITLE
Add user-guide.md with redirect link to the adoc

### DIFF
--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -1,0 +1,4 @@
+# Open Liberty Operator
+
+The documentation for the Open Liberty Operator has been moved. Documentation is now available
+[here](user-guide.adoc).


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Add link to the new adoc user-guide for existing links to the markdown docs
- **Note**: only added this for user-guide but if we would like to add links for other files that got renamed, I can add them to this PR.

