### PR TITLE
Add e2e test for kappnav to openliberty operator

### DIFF
--- a/test/e2e/openliberty_kappnav.go
+++ b/test/e2e/openliberty_kappnav.go
@@ -157,8 +157,6 @@ func useExistingApplications(t *testing.T, f *framework.Framework, ctx *framewor
 	target := types.NamespacedName{Namespace: ns, Name: name}
 
 	err = util.UpdateApplication(f, target, func(r *openlibertyv1beta1.OpenLibertyApplication) {
-		createApp := false
-		r.Spec.CreateAppDefinition = &createApp
 		r.Spec.ApplicationName = existingAppName
 	})
 	if err != nil {

--- a/test/e2e/openliberty_kappnav.go
+++ b/test/e2e/openliberty_kappnav.go
@@ -1,0 +1,206 @@
+package e2e
+
+import (
+	goctx "context"
+	"errors"
+	"testing"
+	"time"
+
+	openlibertyv1beta1 "github.com/OpenLiberty/open-liberty-operator/pkg/apis/openliberty/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+	applicationsv1beta1 "sigs.k8s.io/application/pkg/apis/app/v1beta1"
+
+	"github.com/OpenLiberty/open-liberty-operator/test/util"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	e2eutil "github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
+)
+
+var appName string = "test-app"
+
+// OpenLibertyKappNavTest : Test kappnav feature set
+func OpenLibertyKappNavTest(t *testing.T) {
+
+	ctx, err := util.InitializeContext(t, cleanupTimeout, retryInterval)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ctx.Cleanup()
+
+	f := framework.Global
+	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		t.Fatalf("could not get namespace: %v", err)
+	}
+
+	// add to scheme to framework can find the resource
+	err = applicationsv1beta1.AddToScheme(f.Scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the operator as the following configmaps won't exist until it has deployed
+	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, "open-liberty-operator", 1, retryInterval, operatorTimeout)
+	if err != nil {
+		util.FailureCleanup(t, f, namespace, err)
+	}
+
+	if err = createKappNavApplication(t, f, ctx); err != nil {
+		util.FailureCleanup(t, f, namespace, err)
+	}
+
+	if err = updateKappNavApplications(t, f, ctx); err != nil {
+		util.FailureCleanup(t, f, namespace, err)
+	}
+
+	if err = useExistingApplications(t, f, ctx); err != nil {
+		util.FailureCleanup(t, f, namespace, err)
+	}
+}
+
+func createKappNavApplication(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
+	ns, err := ctx.GetNamespace()
+	if err != nil {
+		return err
+	}
+
+	const name string = "example-openliberty-kappnav"
+
+	openliberty := util.MakeBasicOpenLibertyApplication(t, f, name, ns, 1)
+	openliberty.Spec.ApplicationName = appName
+
+	err = f.Client.Create(goctx.TODO(), openliberty, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
+	if err != nil {
+		return err
+	}
+
+	// Verify readiness of created resource
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, ns, name, 1, retryInterval, timeout)
+	if err != nil {
+		return err
+	}
+
+	target := types.NamespacedName{Namespace: ns, Name: name}
+
+	ok, err := verifyKappNavLabels(t, f, target)
+	if err != nil {
+		return err
+	} else if !ok {
+		return errors.New("could not find kappnav labels")
+	}
+	t.Log("kappnav labels found")
+
+	err = util.WaitForApplicationCreated(t, f, types.NamespacedName{Name: appName, Namespace: ns})
+	if err != nil {
+		return err
+	}
+	t.Log("related application definition found")
+
+	return nil
+}
+
+func updateKappNavApplications(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
+	ns, err := ctx.GetNamespace()
+	if err != nil {
+		return err
+	}
+
+	const name string = "example-openliberty-kappnav"
+
+	target := types.NamespacedName{Namespace: ns, Name: name}
+
+	err = util.UpdateApplication(f, target, func(r *openlibertyv1beta1.OpenLibertyApplication) {
+		appDef := false
+		r.Spec.CreateAppDefinition = &appDef
+	})
+	if err != nil {
+		return err
+	}
+
+	ok, err := verifyKappNavLabels(t, f, target)
+	if err != nil {
+		return err
+	} else if !ok {
+		return errors.New("kappnav labels present after disabling")
+	}
+	t.Log("kappnav labels successfully removed")
+
+	err = util.WaitForApplicationDelete(t, f, types.NamespacedName{Name: appName, Namespace: ns})
+	if err != nil {
+		return err
+	}
+	t.Log("created application definition removed")
+
+	return nil
+}
+
+func useExistingApplications(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
+	ns, err := ctx.GetNamespace()
+	if err != nil {
+		return err
+	}
+
+	const name string = "example-openliberty-kappnav"
+	var existingAppName string = "existing-app"
+	// Add selector labels to verify that app was actually found
+	selectMatchLabels := map[string]string{
+		"test-key": "test-value",
+	}
+
+	// create existing application
+	err = util.CreateApplicationTarget(f, ctx, types.NamespacedName{Name: existingAppName, Namespace: ns}, selectMatchLabels)
+	if err != nil {
+		return err
+	}
+
+	// connect to existing application IN namespace
+	target := types.NamespacedName{Namespace: ns, Name: name}
+
+	err = util.UpdateApplication(f, target, func(r *openlibertyv1beta1.OpenLibertyApplication) {
+		createApp := false
+		r.Spec.CreateAppDefinition = &createApp
+		r.Spec.ApplicationName = existingAppName
+	})
+	if err != nil {
+		return err
+	}
+
+	time.Sleep(5 * time.Second)
+
+	openliberty := &openlibertyv1beta1.OpenLibertyApplication{}
+	err = f.Client.Get(goctx.TODO(), target, openliberty)
+	if err != nil {
+		return err
+	}
+
+	openlibertyLabels := openliberty.Labels
+
+	if _, ok := openlibertyLabels["test-key"]; !ok {
+		return errors.New("selector labels from target application not present")
+	}
+	t.Log("target application correctly applied to the component")
+
+	if openlibertyLabels["app.kubernetes.io/part-of"] != existingAppName {
+		return errors.New("part-of label not correctly set")
+	}
+	t.Log("part-of label correctly set")
+
+	return nil
+}
+
+func verifyKappNavLabels(t *testing.T, f *framework.Framework, target types.NamespacedName) (bool, error) {
+	dep := &appsv1.Deployment{}
+	err := f.Client.Get(goctx.TODO(), target, dep)
+	if err != nil {
+		return false, err
+	}
+
+	labels := dep.GetLabels()
+
+	// verify that label present, full set of annos checked by unit tests
+	if labels["kappnav.app.auto-create"] != "true" {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/test/e2e/openliberty_test.go
+++ b/test/e2e/openliberty_test.go
@@ -68,6 +68,7 @@ func testAdvancedFeatures(t *testing.T) {
 	t.Run("OpenLibertyServiceBindingTest", OpenLibertyServiceBindingTest)
 	t.Run("OpenLibertyCertManagerTest", OpenLibertyCertManagerTest)
 	t.Run("OpenLibertyDumpsTest", OpenLibertyDumpsTest)
+	t.Run("OpenLibertyKappNavTest", OpenLibertyKappNavTest)
 }
 
 // Verify functionality that is tied to OCP

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	openlibertyv1beta1 "github.com/OpenLiberty/open-liberty-operator/pkg/apis/openliberty/v1beta1"
+	applicationsv1beta1 "sigs.k8s.io/application/pkg/apis/app/v1beta1"
 	certmngrv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
@@ -474,4 +475,77 @@ func GetPods(f *framework.Framework, ctx *framework.TestCtx, target string, ns s
 	}
 
 	return podList, nil
+}
+
+// WaitForApplicationDelete wait for kappnav to delete the generated application
+func WaitForApplicationDelete(t *testing.T, f *framework.Framework, target types.NamespacedName) error {
+	retryInterval := time.Second * 5
+	timeout := time.Second * 30
+	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		application := &applicationsv1beta1.Application{}
+
+		if err := f.Client.Get(goctx.TODO(), target, application); err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return true, err
+		}
+
+		t.Logf("application '%s' not deleted, waiting...", target.Name)
+		return false, nil
+	})
+
+	return err
+}
+
+// WaitForApplicationCreated wait for kappnav to create the generated application
+func WaitForApplicationCreated(t *testing.T, f *framework.Framework, target types.NamespacedName) error {
+	retryInterval := time.Second * 5
+	timeout := time.Second * 30
+	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		application := &applicationsv1beta1.Application{}
+
+		if err := f.Client.Get(goctx.TODO(), target, application); err != nil {
+			if apierrors.IsNotFound(err) {
+				t.Logf("application '%s' not found, waiting...", target.Name)
+				return false, nil
+			}
+			return true, err
+		}
+
+		return true, nil
+	})
+
+	return err
+}
+
+func CreateApplicationTarget(f *framework.Framework, ctx *framework.TestCtx, target types.NamespacedName, l map[string]string) error {
+	ns, err := ctx.GetNamespace()
+	if err != nil {
+		return err
+	}
+
+	application := &applicationsv1beta1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: target.Name,
+			Namespace: target.Namespace,
+			Annotations: map[string]string{
+				"kappnav.component.namespaces": ns,
+			},
+		},
+		Spec: applicationsv1beta1.ApplicationSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: l,
+			},
+		},
+	}
+	timeout := time.Second * 30
+	retryInterval := time.Second * 1
+
+	err = f.Client.Create(goctx.TODO(), application, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it?**:


- Ports over kappnav e2e test from [#117](https://github.com/application-stacks/runtime-component-operator/pull/117)
