### PR TITLE
updates from auto-registration testing

### DIFF
--- a/doc/user-guide.adoc
+++ b/doc/user-guide.adoc
@@ -335,19 +335,21 @@ type: Opaque
 data:
   # base64 encode the data before entering it here.
   #
-  # Leave the clientId and secret out, registration will obtain them and update their values
+  # Leave the clientId and secret out, registration will obtain them and update their values.
   # oidc-clientId
   # oidc-clientSecret
-  # Reserved: <provider>-autoreg-registeredClientId and registeredClientSecret also contain these values.
+  #
+  # Reserved: <provider>-autoreg-registeredClientId and registeredClientSecret 
+  # are used by the operator to store a copy of the clientId abd clientSecret values.
   # 
-  # Automatic registration attributes have -autoreg- after the provider name
-
-  # Red Hat Single Sign On requires an initial access token for registration
+  # Automatic registration attributes have -autoreg- after the provider name.
+  #
+  # Red Hat Single Sign On requires an initial access token for registration.
   oidc-autoreg-initialAccessToken: xxxxxyyyyy
   #
   # IBM Security Verify requires a special clientId and clientSecret for registration.
-  # oidc-autoreg-clientId: bW9vb29vb28=
-  # oidc-autoreg-clientSecret: dGhlbGF1Z2hpbmdjb3c=  
+  # oidc-autoreg-initialClientId: bW9vb29vb28=
+  # oidc-autoreg-initialClientSecret: dGhlbGF1Z2hpbmdjb3c=  
   # Optional: Grant types are the types of OAuth flows the resulting clients will allow
   # Default is authorization_code,refresh_token.  Specify a comma separated list.
   # oidc-autoreg-grantTypes: base64 data goes here
@@ -367,8 +369,6 @@ For IBM Security Verify, set the attribute to given_name.
 
 You can use multiple OIDC and OAuth 2.0 providers to authenticate with. First, configure and build application image with multiple OIDC and/or OAuth 2.0 providers. For example, set `ARG SEC_SSO_PROVIDERS="google oidc:provider1,provider2 oauth2:provider3,provider4"` in your Dockerfile. The provider name must be unique and must contain only alphanumeric characters.
 
-Then, use the provider name in SSO `Secret` to specify its client ID and secret. For example, `provider1-clientSecret: dGhlbGF1Z2hpbmdjb3c=`. To configure a parameter for the corresponding provider in `OpenLibertyApplication` CR, use `sso.oidc[].id` or `sso.oauth2[].id` parameter.
-
 [source,yaml]
 ----
   sso:
@@ -384,6 +384,32 @@ Then, use the provider name in SSO `Secret` to specify its client ID and secret.
       - id: provider4
         authorizationEndpoint: specify-required-value
         tokenEndpoint: specify-required-value
+----
+
+Next, use the provider name in SSO `Secret` to specify its client ID and secret. For example, `provider1-clientSecret: dGhlbGF1Z2hpbmdjb3c=`. To configure a parameter for the corresponding provider in `OpenLibertyApplication` CR, use `sso.oidc[].id` or `sso.oauth2[].id` parameter as in the following example.
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  # Name of the secret should be in this format: <OpenLibertyApplication_name>-olapp-sso
+  name: my-app-olapp-sso
+  # Secret must be created in the same namespace as the OpenLibertyApplication instance
+  namespace: demo
+type: Opaque
+data:
+  # The keys must be in this format: <provider_name>-<sensitive_field_name>
+  google-clientId: xxxxxxxxxxxxx
+  google-clientSecret: yyyyyyyyyyyyyy
+  provider1-clientId: bW9vb29vb28=
+  provider1-clientSecret: dGhlbGF1Z2hpbmdjb3c=
+  provider2-autoreg-initialClientId: bW9vb29vb28=
+  provider2-autoreg-initialClientSecret: dGhlbGF1Z2hpbmdjb3c=
+  provider3-clientId: bW9vb29vb28=
+  provider3-clientSecret: dGhlbGF1Z2hpbmdjb3c=
+  provider4-clientId: bW9vb29vb28=
+  provider4-clientSecret: dGhlbGF1Z2hpbmdjb3c=  
 ----
 
 === Storage for serviceability

--- a/doc/user-guide.adoc
+++ b/doc/user-guide.adoc
@@ -320,7 +320,7 @@ spec:
 
 ==== Using automatic registration with OIDC providers
 
-The operator can request a client Id and client Secret from providers, rather than requiring them in advance. This can simplify deployment, as the provider's administrator can supply the information needed for registration once, instead of supplying clientIds and secrets repetitively.  Additional attributes named `<provider_name>-autoreg-<field_name>` are added to the secret shown above.  First the operator will make an https request to the `sso.oidc[].discoveryEndpoint` to obtain URLs for subsequent REST calls.  Next it will make additional REST calls to the provider and obtain a client Id and client Secret. The secret will be updated with the obtained values. This is tested with Red Hat Single Sign-on (RHSSO). See the following example. 
+The operator can request a client Id and client Secret from providers, rather than requiring them in advance. This can simplify deployment, as the provider's administrator can supply the information needed for registration once, instead of supplying clientIds and secrets repetitively.  The callback URL from provider to client is supplied by the operator, so doesn't need to be known in advance. Additional attributes named `<provider_name>-autoreg-<field_name>` are added to the Kubernetes secret shown below.  First the operator will make an https request to the `sso.oidc[].discoveryEndpoint` to obtain URLs for subsequent REST calls.  Next it will make additional REST calls to the provider and obtain a client Id and client Secret. The Kubernetes secret will be updated with the obtained values. This is tested on OpenShift with Red Hat Single Sign-on (RHSSO) and IBM Security Verify. See the following example. 
 
 [source,yaml]
 ----
@@ -339,8 +339,8 @@ data:
   # oidc-clientId
   # oidc-clientSecret
   #
-  # Reserved: <provider>-autoreg-registeredClientId and registeredClientSecret 
-  # are used by the operator to store a copy of the clientId abd clientSecret values.
+  # Reserved: <provider>-autoreg-RegisteredClientId and RegisteredClientSecret 
+  # are used by the operator to store a copy of the clientId and clientSecret values.
   # 
   # Automatic registration attributes have -autoreg- after the provider name.
   #
@@ -350,6 +350,7 @@ data:
   # IBM Security Verify requires a special clientId and clientSecret for registration.
   # oidc-autoreg-initialClientId: bW9vb29vb28=
   # oidc-autoreg-initialClientSecret: dGhlbGF1Z2hpbmdjb3c=  
+  #
   # Optional: Grant types are the types of OAuth flows the resulting clients will allow
   # Default is authorization_code,refresh_token.  Specify a comma separated list.
   # oidc-autoreg-grantTypes: base64 data goes here

--- a/pkg/utils/register.go
+++ b/pkg/utils/register.go
@@ -51,8 +51,9 @@ func doRegister(rdata RegisterData) (string, string, error) {
 	// ICI: if we don't have initial token, use client and secret to go get one.
 	var token = rdata.InitialAccessToken
 	if token == "" && (rdata.InitialClientId == "" || rdata.InitialClientSecret == "") {
-		return "", "", gherrors.New("Provider " + rdata.ProviderId + ": registration data for Single sign-on (SSO) is missing required fields," +
-			" one or more of initialAccessToken, initialClientId, or initialClientSecret.")
+	    id := rdata.ProviderId
+		return "", "", gherrors.New("Provider " + id + ": registration data for Single sign-on (SSO) is missing required fields," +
+			" one or more of " + id + "-autoreg-initialAccessToken, " + id + "-autoreg-initialClientId, or " + id + "-autoreg-initialClientSecret.")
 	}
 	if token == "" {
 		rtoken, err := requestAccessToken(rdata, tokenURL)


### PR DESCRIPTION
**What this PR does / why we need it?**:
Fixes several problems found in testing of oidc autoregistration of the operator.
  - some field names in the userguide were wrong.
  - added sample secret to userguide to clarify how to compose the secret
  - registration data could be lost if an error occured when registering multiple providers.
    - write secret before aborting to preserve partial registration data 
  - updated messages to use correct field names and added some logging 
**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [x ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #177 #176
