### PR TITLE
Add day2 operations annotation to CSV

### DIFF
--- a/deploy/olm-catalog/open-liberty-operator-certified/open-liberty-operator.v0.7.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/open-liberty-operator-certified/open-liberty-operator.v0.7.0.clusterserviceversion.yaml
@@ -14,6 +14,47 @@ metadata:
     support: IBM
     capabilities: Auto Pilot
     repository: https://github.com/OpenLiberty/open-liberty-operator
+    owned.crd.extensions: |-
+      - name: openlibertyapplications.openliberty.io
+        operations:
+          - openlibertytraces.openliberty.io
+          - openlibertydumps.openliberty.io
+      - name: openlibertytraces.openliberty.io
+        actionName: Liberty Trace
+        targetKinds:
+          - Deployment
+          - Pod
+        specDescriptors:
+          - path: podName
+            v-descriptors:
+            - urn:alm:descriptor:io.operations.value:target-resource:kind=Pod:metadata.name
+            - urn:alm:descriptor:io.operations.value:target-resource:kind=Deployment:PodList
+            x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:MultiSelectList:target-resource:kind=Deployment
+          - path: disable
+            displayName: Disable tracing
+          - path: maxFileSize
+            displayName: Maximum file size
+          - path: maxFiles
+            displayName: Maximum number of files
+          - path: traceSpecification
+            displayName: Trace specification string
+      - name: openlibertydumps.openliberty.io
+        actionName: Liberty Dump
+        targetKinds:
+          - Deployment
+          - Pod
+        specDescriptors:
+          - path: podName
+            v-descriptors:
+            - urn:alm:descriptor:io.operations.value:target-resource:kind=Pod:metadata.name
+            - urn:alm:descriptor:io.operations.value:target-resource:kind=Deployment:PodList
+            x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:MultiSelectList:target-resource:kind=Deployment
+          - path: include
+            displayName: Dump types
+            x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:MultiSelectList:target-resource:kind=Deployment
 spec:
   displayName: Open Liberty Operator
   description: 'This advanced Operator can be used to deploy and manage Open Liberty applications with 

--- a/deploy/olm-catalog/open-liberty-operator-community/0.7.0/open-liberty-operator.v0.7.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/open-liberty-operator-community/0.7.0/open-liberty-operator.v0.7.0.clusterserviceversion.yaml
@@ -14,6 +14,47 @@ metadata:
     support: IBM
     capabilities: Auto Pilot
     repository: https://github.com/OpenLiberty/open-liberty-operator
+    owned.crd.extensions: |-
+      - name: openlibertyapplications.openliberty.io
+        operations:
+          - openlibertytraces.openliberty.io
+          - openlibertydumps.openliberty.io
+      - name: openlibertytraces.openliberty.io
+        actionName: Liberty Trace
+        targetKinds:
+          - Deployment
+          - Pod
+        specDescriptors:
+          - path: podName
+            v-descriptors:
+            - urn:alm:descriptor:io.operations.value:target-resource:kind=Pod:metadata.name
+            - urn:alm:descriptor:io.operations.value:target-resource:kind=Deployment:PodList
+            x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:MultiSelectList:target-resource:kind=Deployment
+          - path: disable
+            displayName: Disable tracing
+          - path: maxFileSize
+            displayName: Maximum file size
+          - path: maxFiles
+            displayName: Maximum number of files
+          - path: traceSpecification
+            displayName: Trace specification string
+      - name: openlibertydumps.openliberty.io
+        actionName: Liberty Dump
+        targetKinds:
+          - Deployment
+          - Pod
+        specDescriptors:
+          - path: podName
+            v-descriptors:
+            - urn:alm:descriptor:io.operations.value:target-resource:kind=Pod:metadata.name
+            - urn:alm:descriptor:io.operations.value:target-resource:kind=Deployment:PodList
+            x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:MultiSelectList:target-resource:kind=Deployment
+          - path: include
+            displayName: Dump types
+            x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:MultiSelectList:target-resource:kind=Deployment
 spec:
   displayName: Open Liberty Operator
   description: 'This advanced Operator can be used to deploy and manage Open Liberty applications with 


### PR DESCRIPTION
**What this PR does / why we need it?**:

This PR adds an annotation to the CSV that will be detected and used by App Navigator to automatically produce menu items and dialogs in the App Nav UI for submitting day 2 operations - currently trace and dump.

**Does this PR introduce a user-facing change?**
This PR does not produce a user facing change to for the OLM catalog UI or any API, so no OpenLiberty operator doc changes are needed.

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes # Issue to be created...
