### PR TITLE
Re-add websphere tests for basic cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
     if: fork = false
   - name: E2E testing on OCP 4.3 with WebSphere Liberty
     script: make test-e2e
-    env: LIBERTY_IMAGE="ibmcom/websphere-liberty:kernel-java8-ibmjava-ubi"
+    env: LIBERTY_IMAGE="ibmcom/websphere-liberty:full-java8-ibmjava-ubi"
     if: fork = false
   ## if master branch build and push image for amd64,ppc64le,s390 to DH
   - name: Build image on amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,10 @@ jobs:
     script: make test-e2e
     env: LIBERTY_IMAGE="openliberty/open-liberty:kernel-java8-openj9-ubi"
     if: fork = false
-  # - name: E2E testing on OCP 4.3 with WebSphere Liberty
-  #   script: make test-e2e
-  #   env: LIBERTY_IMAGE="ibmcom/websphere-liberty:full-java8-ibmjava-ubi"
-  #   if: fork = false
+  - name: E2E testing on OCP 4.3 with WebSphere Liberty
+    script: make test-e2e
+    env: LIBERTY_IMAGE="ibmcom/websphere-liberty:kernel-java8-ibmjava-ubi"
+    if: fork = false
   ## if master branch build and push image for amd64,ppc64le,s390 to DH
   - name: Build image on amd64
     stage: build

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -45,7 +45,13 @@ main() {
     fi
 
     echo "****** Starting e2e tests..."
-    CLUSTER_ENV="ocp" operator-sdk test local github.com/OpenLiberty/open-liberty-operator/test/e2e --go-test-flags "-timeout 35m" --image $(oc registry info)/openshift/operator:$TRAVIS_BUILD_NUMBER --verbose
+    ## just run basic tests for websphere for performance issues
+    if [[ "${LIBERTY_IMAGE}" =~ "websphere" ]]; then
+      CLUSTER_ENV="minikube" operator-sdk test local github.com/OpenLiberty/open-liberty-operator/test/e2e --go-test-flags "-timeout 35m" --image $(oc registry info)/openshift/operator:$TRAVIS_BUILD_NUMBER --verbose
+    else
+      CLUSTER_ENV="ocp" operator-sdk test local github.com/OpenLiberty/open-liberty-operator/test/e2e --go-test-flags "-timeout 35m" --image $(oc registry info)/openshift/operator:$TRAVIS_BUILD_NUMBER --verbose
+    fi
+
     result=$?
     echo "****** Cleaning up tests..."
     cleanup

--- a/test/e2e/openliberty_test.go
+++ b/test/e2e/openliberty_test.go
@@ -102,7 +102,7 @@ func TestOpenLibertyApplication(t *testing.T) {
 	if cluster == "ocp" {
 		for _, test := range ocpTests {
 			wg.Add(1)
-			go RuntimeTestRunner(&wg, t, test)
+			RuntimeTestRunner(&wg, t, test)
 		}
 	}
 	wg.Wait()

--- a/test/e2e/openliberty_test.go
+++ b/test/e2e/openliberty_test.go
@@ -80,7 +80,7 @@ func TestOpenLibertyApplication(t *testing.T) {
 		if cluster == "minikube" {
 			RuntimeTestRunner(&wg, t, test)
 		} else {
-			RuntimeTestRunner(&wg, t, test)
+			go RuntimeTestRunner(&wg, t, test)
 		}
 	}
 

--- a/test/e2e/openliberty_test.go
+++ b/test/e2e/openliberty_test.go
@@ -86,21 +86,21 @@ func TestOpenLibertyApplication(t *testing.T) {
 
 	// tests for features that will require cluster configuration
 	// i.e. knative requires installations
-	if cluster != "minikube" {
-		for _, test := range advancedTests {
-			wg.Add(1)
-			RuntimeTestRunner(&wg, t, test)
-		}
-	}
+	// if cluster != "minikube" {
+	// 	for _, test := range advancedTests {
+	// 		wg.Add(1)
+	// 		RuntimeTestRunner(&wg, t, test)
+	// 	}
+	// }
 
 	// tests for features NOT expected to run in OpenShift
 	// i.e. Ingress
-	if cluster == "minikube" || cluster == "kubernetes" {
-		for _, test := range independantTests {
-			wg.Add(1)
-			RuntimeTestRunner(&wg, t, test)
-		}
-	}
+	// if cluster == "minikube" || cluster == "kubernetes" {
+	// 	for _, test := range independantTests {
+	// 		wg.Add(1)
+	// 		RuntimeTestRunner(&wg, t, test)
+	// 	}
+	// }
 
 	// tests for features that ONLY exist in OpenShift
 	// i.e. image streams are only in OpenShift

--- a/test/e2e/openliberty_test.go
+++ b/test/e2e/openliberty_test.go
@@ -80,34 +80,34 @@ func TestOpenLibertyApplication(t *testing.T) {
 		if cluster == "minikube" {
 			RuntimeTestRunner(&wg, t, test)
 		} else {
-			go RuntimeTestRunner(&wg, t, test)
+			RuntimeTestRunner(&wg, t, test)
 		}
 	}
 
 	// tests for features that will require cluster configuration
 	// i.e. knative requires installations
-	// if cluster != "minikube" {
-	// 	for _, test := range advancedTests {
-	// 		wg.Add(1)
-	// 		RuntimeTestRunner(&wg, t, test)
-	// 	}
-	// }
+	if cluster != "minikube" {
+		for _, test := range advancedTests {
+			wg.Add(1)
+			RuntimeTestRunner(&wg, t, test)
+		}
+	}
 
 	// tests for features NOT expected to run in OpenShift
 	// i.e. Ingress
-	// if cluster == "minikube" || cluster == "kubernetes" {
-	// 	for _, test := range independantTests {
-	// 		wg.Add(1)
-	// 		RuntimeTestRunner(&wg, t, test)
-	// 	}
-	// }
+	if cluster == "minikube" || cluster == "kubernetes" {
+		for _, test := range independantTests {
+			wg.Add(1)
+			go RuntimeTestRunner(&wg, t, test)
+		}
+	}
 
 	// tests for features that ONLY exist in OpenShift
 	// i.e. image streams are only in OpenShift
 	if cluster == "ocp" {
 		for _, test := range ocpTests {
 			wg.Add(1)
-			RuntimeTestRunner(&wg, t, test)
+			go RuntimeTestRunner(&wg, t, test)
 		}
 	}
 	wg.Wait()

--- a/test/e2e/openliberty_test.go
+++ b/test/e2e/openliberty_test.go
@@ -76,7 +76,12 @@ func TestOpenLibertyApplication(t *testing.T) {
 	// basic tests that are runnable locally in minishift/kube
 	for _, test := range basicTests {
 		wg.Add(1)
-		go RuntimeTestRunner(&wg, t, test)
+		// minikube can't support the goroutine approach
+		if cluster == "minikube" {
+			RuntimeTestRunner(&wg, t, test)
+		} else {
+			go RuntimeTestRunner(&wg, t, test)
+		}
 	}
 
 	// tests for features that will require cluster configuration


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Add tests that run in the 4.3 cluster for websphere images, but run the same basic suite as minikube job.
- Fix issues with minikube tests, by running outside of goroutines

