### PR TITLE
Update query for pod variable in grafana dashboards

### DIFF
--- a/deploy/dashboards/metrics/RHOCP4.3-GrafanaOperator3.0.2-Grafana5.2/open-liberty-grafana-mpMetrics1.x.yml
+++ b/deploy/dashboards/metrics/RHOCP4.3-GrafanaOperator3.0.2-Grafana5.2/open-liberty-grafana-mpMetrics1.x.yml
@@ -2053,7 +2053,7 @@ spec:
             "options": [],
             "query": "base:cpu_available_processors",
             "refresh": 1,
-            "regex": "/base:cpu_available_processors{.*pod=\"(.*)\",service=.*/",
+            "regex": "/base:cpu_available_processors{.*pod=\"(.*?)\".*/",
             "skipUrlSync": false,
             "sort": 1,
             "tagValuesQuery": "",

--- a/deploy/dashboards/metrics/RHOCP4.3-GrafanaOperator3.0.2-Grafana5.2/open-liberty-grafana-mpMetrics2.x.yml
+++ b/deploy/dashboards/metrics/RHOCP4.3-GrafanaOperator3.0.2-Grafana5.2/open-liberty-grafana-mpMetrics2.x.yml
@@ -3250,7 +3250,7 @@ spec:
             "options": [],
             "query": "base_cpu_processCpuLoad_percent",
             "refresh": 1,
-            "regex": "/base_cpu_processCpuLoad_percent{.*pod=\"(.*)\",service=.*/",
+            "regex": "/base_cpu_processCpuLoad_percent{.*pod=\"(.*?)\".*/",
             "skipUrlSync": false,
             "sort": 1,
             "tagValuesQuery": "",


### PR DESCRIPTION
**What this PR does / why we need it?**:
This PR is needed because when Thanos is used as a data source, the Grafana dashboards does not work. The pod query adds the prometheus server where the data comes from which results to the value of the pod variable being incorrect.
e.g.
Thanos current pod value:  `mydemoapp-7575584657-6c9vl",prometheus="openshift-user-workload-monitoring/user-workload `
Filtered out prometheus for pod value:  `mydemoapp-7575584657-6c9vl `
**Which issue(s) this PR fixes**:
Fixes #190 
