### PR TITLE
Check pods labels during kuttl tests

### DIFF
--- a/bundle/tests/scorecard/kuttl/annotations/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/annotations/00-assert.yaml
@@ -31,3 +31,5 @@ metadata:
     bar2: foo2
     foo1: bar1
     conflict: deployment
+  labels:
+    app.kubernetes.io/instance: lib-deployment-annotations

--- a/bundle/tests/scorecard/kuttl/annotations/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/annotations/01-assert.yaml
@@ -30,3 +30,6 @@ metadata:
     bar2: foo2
     foo1: bar1
     conflict: statefulSet
+  labels:
+    app.kubernetes.io/instance: lib-deployment-annotations
+

--- a/bundle/tests/scorecard/kuttl/image-stream/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/image-stream/01-assert.yaml
@@ -18,3 +18,6 @@ spec:
 status:
   containerStatuses:
   - ready: true
+metadata:
+  labels:
+    app.kubernetes.io/instance: imagestream-liberty-app

--- a/bundle/tests/scorecard/kuttl/image-stream/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/image-stream/02-assert.yaml
@@ -13,3 +13,7 @@ spec:
 status:
   containerStatuses:
   - ready: true
+metadata:
+  labels:
+    app.kubernetes.io/instance: imagestream-liberty-app
+

--- a/bundle/tests/scorecard/kuttl/image-stream/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/image-stream/03-assert.yaml
@@ -18,4 +18,7 @@ spec:
 status:
   containerStatuses:
   - ready: true
+metadata:
+  labels:
+    app.kubernetes.io/instance: imagestream-liberty-app
 

--- a/bundle/tests/scorecard/kuttl/image-stream/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/image-stream/04-assert.yaml
@@ -18,4 +18,7 @@ spec:
 status:
   containerStatuses:
   - ready: true
+metadata:
+  labels:
+    app.kubernetes.io/instance: imagestream-liberty-app
 

--- a/bundle/tests/scorecard/kuttl/probe/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/00-assert.yaml
@@ -16,3 +16,6 @@ spec:
       startupProbe:
         failureThreshold: 10
         periodSeconds: 5
+metadata:
+  labels:
+    app.kubernetes.io/instance: probes-liberty

--- a/bundle/tests/scorecard/kuttl/probe/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/01-assert.yaml
@@ -16,3 +16,7 @@ spec:
       startupProbe:
         failureThreshold: 20
         periodSeconds: 10
+metadata:
+  labels:
+    app.kubernetes.io/instance: probes-liberty
+

--- a/bundle/tests/scorecard/kuttl/probe/02-errors.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/02-errors.yaml
@@ -9,3 +9,7 @@ spec:
       startupProbe:
         failureThreshold: 20
         periodSeconds: 10
+metadata:
+  labels:
+    app.kubernetes.io/instance: probes-liberty
+

--- a/bundle/tests/scorecard/kuttl/pullpolicy/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/pullpolicy/00-assert.yaml
@@ -14,3 +14,6 @@ kind: Pod
 spec:   
   containers:
   - imagePullPolicy: "Always"
+metadata:
+  labels:
+    app.kubernetes.io/instance: example-openliberty-applicaion

--- a/bundle/tests/scorecard/kuttl/pullpolicy/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/pullpolicy/01-assert.yaml
@@ -14,3 +14,6 @@ kind: Pod
 spec:   
   containers:
   - imagePullPolicy: "IfNotPresent"
+metadata:
+  labels:
+    app.kubernetes.io/instance: example-openliberty-applicaion

--- a/bundle/tests/scorecard/kuttl/pullpolicy/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/pullpolicy/02-assert.yaml
@@ -14,3 +14,6 @@ kind: Pod
 spec:   
   containers:
   - imagePullPolicy: "Never"
+metadata:
+  labels:
+    app.kubernetes.io/instance: example-openliberty-applicaion

--- a/bundle/tests/scorecard/kuttl/pullpolicy/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/pullpolicy/03-assert.yaml
@@ -14,3 +14,6 @@ kind: Pod
 spec:   
   containers:
   - imagePullPolicy: "IfNotPresent"
+metadata:
+  labels:
+    app.kubernetes.io/instance: example-openliberty-applicaion

--- a/bundle/tests/scorecard/kuttl/sso1-social/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/sso1-social/01-assert.yaml
@@ -12,6 +12,9 @@ status:
 # It also seems that order is important, so this could be fragile
 apiVersion: v1
 kind: Pod
+metadata:
+  labels:
+    app.kubernetes.io/instance: sso-liberty
 spec:
   containers:
   - env:

--- a/bundle/tests/scorecard/kuttl/sso1-social/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/sso1-social/02-assert.yaml
@@ -23,6 +23,9 @@ status:
 # It also seems that order is important, so this could be fragile
 apiVersion: v1
 kind: Pod
+metadata:
+  labels:
+    app.kubernetes.io/instance: sso-liberty
 spec:
   containers:
   - env:

--- a/bundle/tests/scorecard/kuttl/sso1-social/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/sso1-social/03-assert.yaml
@@ -12,6 +12,9 @@ status:
 # It also seems that order is important, so this could be fragile
 apiVersion: v1
 kind: Pod
+metadata:
+  labels:
+    app.kubernetes.io/instance: sso-liberty
 spec:
   containers:
   - env:

--- a/bundle/tests/scorecard/kuttl/sso2-providers/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/sso2-providers/01-assert.yaml
@@ -12,6 +12,9 @@ status:
 # It also seems that order is important, so this could be fragile
 apiVersion: v1
 kind: Pod
+metadata:
+  labels:
+    app.kubernetes.io/instance: provider-liberty
 spec:
   containers:
   - env:

--- a/bundle/tests/scorecard/kuttl/sso2-providers/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/sso2-providers/02-assert.yaml
@@ -12,6 +12,9 @@ status:
 # It also seems that order is important, so this could be fragile
 apiVersion: v1
 kind: Pod
+metadata:
+  labels:
+    app.kubernetes.io/instance: provider-liberty
 spec:
   containers:
   - env:


### PR DESCRIPTION
This ensure that the pods being asserted on are from
the current test



