### PR TITLE
Add an x-descriptor for the Openliberty Dump path

### DIFF
--- a/bundle/manifests/open-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/open-liberty.clusterserviceversion.yaml
@@ -341,6 +341,12 @@ spec:
       kind: OpenLibertyDump
       name: openlibertydumps.apps.openliberty.io
       version: v1beta2
+      statusDescriptors:
+      - description: Location of the generated dump file
+        displayName: Dump Path
+        path: dumpFile
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
     - description: Day-2 operation for gathering server traces
       displayName: OpenLibertyTrace
       kind: OpenLibertyTrace

--- a/config/manifests/bases/open-liberty.clusterserviceversion.yaml
+++ b/config/manifests/bases/open-liberty.clusterserviceversion.yaml
@@ -298,6 +298,11 @@ spec:
       kind: OpenLibertyDump
       name: openlibertydumps.apps.openliberty.io
       version: v1beta2
+      statusDescriptors:
+      - displayName: Dump Path
+        path: dumpFile
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
     - description: Day-2 operation for gathering server traces
       displayName: OpenLibertyTrace
       kind: OpenLibertyTrace


### PR DESCRIPTION
Signed-off-by: Jason Yong <jason_yong@uk.ibm.com>

**What this PR does / why we need it?**:

- Adds an x-descriptor for the dump path so it is rendered in the UI

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #299 
