### PR TITLE
 Add kustomization patch to add description for service binding secret

### DIFF
--- a/bundle/manifests/open-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/open-liberty.clusterserviceversion.yaml
@@ -335,6 +335,11 @@ spec:
         path: conditions
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.conditions
+      - description: Service Binding Secret
+        displayName: Secret
+        path: binding.name
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
       version: v1beta2
     - description: Day-2 operation for generating server dumps
       displayName: OpenLibertyDump

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -6,6 +6,13 @@ resources:
 - ../samples
 - ../scorecard
 
+patches:
+- path: serviceBindingPatch.yaml
+  target:
+    kind: ClusterServiceVersion
+    name: open-liberty.v0.0.0
+    namespace: placeholder
+
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
 # These patches remove the unnecessary "cert" volume and its manager container volumeMount.

--- a/config/manifests/serviceBindingPatch.yaml
+++ b/config/manifests/serviceBindingPatch.yaml
@@ -1,0 +1,10 @@
+- op: add
+  # the '-' means add a new entry at the end of the list
+  path: /spec/customresourcedefinitions/owned/0/statusDescriptors/-
+  value:
+    description: Service Binding Secret
+    displayName: Secret
+    path: binding.name
+    x-descriptors:
+    - urn:alm:descriptor:io.kubernetes:Secret
+


### PR DESCRIPTION
This allows the service binding secret to be displayed in the OpenShift UI.
The description annotations need to be added as a kustomize patch,
 as the secret field isn't specified in types.go, so annotations can't be added there.