### PR TITLE
Auto update csv for containerImage and createdAt

### DIFF
--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -5,7 +5,8 @@ resources:
 - ../default
 - ../samples
 - ../scorecard
-
+patchesStrategicMerge:
+  - patches/csvAnnotations.yaml
 patches:
 - path: serviceBindingPatch.yaml
   target:

--- a/config/manifests/patches/csvAnnotations.yaml
+++ b/config/manifests/patches/csvAnnotations.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: open-liberty.v0.0.0
+  namespace: placeholder
+  annotations:
+    containerImage: IMAGE
+    createdAt: CREATEDAT


### PR DESCRIPTION
Signed-off-by: Jason Yong <jason_yong@uk.ibm.com>

**What this PR does / why we need it?**:

- Issue opened in [RCO](https://github.com/application-stacks/runtime-component-operator/issues/292)
- Auto updates the containerImage and createdAt values when `make bundle` is run