### PR TITLE
Improve service-certificate test

### DIFF
--- a/bundle/tests/scorecard/kuttl/service-certificate/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-certificate/01-assert.yaml
@@ -11,7 +11,17 @@ spec:
   template:
     spec:
       containers:
-      - volumeMounts:
+      - env:
+        - name: TLS_DIR
+          value: /etc/x509/certs
+        - name: WLP_LOGGING_CONSOLE_LOGLEVEL
+          value: info
+        - name: WLP_LOGGING_CONSOLE_SOURCE
+          value: message,accessLog,ffdc,audit
+        - name: WLP_LOGGING_CONSOLE_FORMAT
+          value: json
+        - name: SERVICE_CERT_SECRET_RESOURCE_VERSION
+        volumeMounts:
         - name: svc-certificate
           mountPath: /etc/x509/certs
           readOnly: true

--- a/bundle/tests/scorecard/kuttl/service-certificate/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-certificate/01-assert.yaml
@@ -10,6 +10,11 @@ status:
 spec:
   template:
     spec:
+      containers:
+      - volumeMounts:
+        - name: svc-certificate
+          mountPath: /etc/x509/certs
+          readOnly: true
       volumes:
       - name: svc-certificate
         secret:


### PR DESCRIPTION
Check for the volume mount existing and being read only

This is to deal with issue application-stacks/runtime-component-operator#313

The test isn't quite the same as the one from the RCO, as on OpenLiberty, the Deployment env contains a field "SERVICE_CERT_SECRET_RESOURCE_VERSION" which has a unique value, and so can't be asserted on