### PR TITLE
Fix for intermittent kuttl test issue

### DIFF
--- a/bundle/tests/scorecard/kuttl/dump/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/dump/00-assert.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: my-liberty-app
+  name: dump-ol
 status:
   replicas: 1
   readyReplicas: 1

--- a/bundle/tests/scorecard/kuttl/dump/00-liberty.yaml
+++ b/bundle/tests/scorecard/kuttl/dump/00-liberty.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps.openliberty.io/v1beta2
 kind: OpenLibertyApplication
 metadata:
-  name: my-liberty-app
+  name: dump-ol
 spec:
   applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
   replicas: 1

--- a/bundle/tests/scorecard/kuttl/dump/01-dump.yaml
+++ b/bundle/tests/scorecard/kuttl/dump/01-dump.yaml
@@ -3,7 +3,7 @@ kind: OpenLibertyDump
 metadata:
   name: test-dump
 spec:
-  podName: my-liberty-app-0
+  podName: dump-ol-0
   include:
     - thread
     - heap

--- a/bundle/tests/scorecard/kuttl/trace/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/trace/00-assert.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: my-liberty-app
+  name: trace-ol
 status:
   replicas: 2
   readyReplicas: 2

--- a/bundle/tests/scorecard/kuttl/trace/00-liberty.yaml
+++ b/bundle/tests/scorecard/kuttl/trace/00-liberty.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps.openliberty.io/v1beta2
 kind: OpenLibertyApplication
 metadata:
-  name: my-liberty-app
+  name: trace-ol
 spec:
   applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
   replicas: 2

--- a/bundle/tests/scorecard/kuttl/trace/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/trace/01-assert.yaml
@@ -3,7 +3,7 @@ kind: OpenLibertyTrace
 metadata:
   name: example-trace
 spec:
-  podName: my-liberty-app-0
+  podName: trace-ol-0
   traceSpecification: "*=info:com.ibm.ws.webcontainer*=all"
   maxFileSize: 20
   maxFiles: 5
@@ -14,5 +14,5 @@ status:
     - status: 'True'
       type: Enabled
   operatedResource:
-    resourceName: my-liberty-app-0
+    resourceName: trace-ol-0
     resourceType: pod

--- a/bundle/tests/scorecard/kuttl/trace/01-trace.yaml
+++ b/bundle/tests/scorecard/kuttl/trace/01-trace.yaml
@@ -3,7 +3,7 @@ kind: OpenLibertyTrace
 metadata:
   name: example-trace
 spec:
-  podName: my-liberty-app-0
+  podName: trace-ol-0
   traceSpecification: "*=info:com.ibm.ws.webcontainer*=all"
   maxFileSize: 20
   maxFiles: 5

--- a/bundle/tests/scorecard/kuttl/trace/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/trace/02-assert.yaml
@@ -3,7 +3,7 @@ kind: OpenLibertyTrace
 metadata:
   name: example-trace
 spec:
-  podName: my-liberty-app-1
+  podName: trace-ol-1
   traceSpecification: "*=info:com.ibm.ws.webcontainer*=all"
   maxFileSize: 20
   maxFiles: 5
@@ -13,5 +13,5 @@ status:
     - status: 'True'
       type: Enabled
   operatedResource:
-    resourceName: my-liberty-app-1
+    resourceName: trace-ol-1
     resourceType: pod

--- a/bundle/tests/scorecard/kuttl/trace/02-change-pod.yaml
+++ b/bundle/tests/scorecard/kuttl/trace/02-change-pod.yaml
@@ -3,7 +3,7 @@ kind: OpenLibertyTrace
 metadata:
   name: example-trace
 spec:
-  podName: my-liberty-app-1
+  podName: trace-ol-1
   traceSpecification: "*=info:com.ibm.ws.webcontainer*=all"
   maxFileSize: 20
   maxFiles: 5

--- a/bundle/tests/scorecard/kuttl/trace/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/trace/03-assert.yaml
@@ -3,7 +3,7 @@ kind: OpenLibertyTrace
 metadata:
   name: example-trace
 spec:
-  podName: my-liberty-app-1
+  podName: trace-ol-1
   traceSpecification: "*=info:com.ibm.ws.webcontainer*=all"
   maxFileSize: 20
   maxFiles: 5
@@ -13,5 +13,5 @@ status:
     - status: 'False'
       type: Enabled
   operatedResource:
-    resourceName: my-liberty-app-1
+    resourceName: trace-ol-1
     resourceType: pod

--- a/bundle/tests/scorecard/kuttl/trace/03-trace-disable.yaml
+++ b/bundle/tests/scorecard/kuttl/trace/03-trace-disable.yaml
@@ -3,7 +3,7 @@ kind: OpenLibertyTrace
 metadata:
   name: example-trace
 spec:
-  podName: my-liberty-app-1
+  podName: trace-ol-1
   traceSpecification: "*=info:com.ibm.ws.webcontainer*=all"
   maxFileSize: 20
   maxFiles: 5

--- a/bundle/tests/scorecard/kuttl/trace/04-delete-app.yaml
+++ b/bundle/tests/scorecard/kuttl/trace/04-delete-app.yaml
@@ -4,4 +4,4 @@ kind: TestStep
 delete:
   - apiVersion: apps.openliberty.io/v1beta2
     kind: OpenLibertyApplication
-    name: dump-ol
+    name: trace-ol


### PR DESCRIPTION
Signed-off-by: Jason Yong <jason_yong@uk.ibm.com>

**What this PR does / why we need it?**:

- Fixes an issue where if the Trace or Dump kuttl tests are run before Basic, Basic will fail due to leftover resources
