### PR TITLE
Fix for multiple /'s in application image name

### DIFF
--- a/controllers/openlibertyapplication_controller.go
+++ b/controllers/openlibertyapplication_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+    "strings"
 
 	networkingv1 "k8s.io/api/networking/v1"
 
@@ -200,7 +201,7 @@ func (r *ReconcileOpenLiberty) Reconcile(ctx context.Context, request ctrl.Reque
 				if image.DockerImageReference != "" {
 					instance.Status.ImageReference = image.DockerImageReference
 				}
-			} else if err != nil && !kerrors.IsNotFound(err) && !kerrors.IsForbidden(err) {
+			} else if err != nil && !kerrors.IsNotFound(err) && !kerrors.IsForbidden(err) && !strings.Contains(isTagName, "/") {
 				return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Jason Yong <jason_yong@uk.ibm.com>

**What this PR does / why we need it?**:

- Allows the image name to have multiple /'s


**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #326 
