### PR TITLE
Default targetport to port value in the CR if not set

### DIFF
--- a/api/v1beta2/openlibertyapplication_types.go
+++ b/api/v1beta2/openlibertyapplication_types.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
@@ -914,6 +915,13 @@ func (cr *OpenLibertyApplication) Initialize() {
 		cr.Spec.Service.Port = 9080
 	}
 
+	// If TargetPorts on Serviceports are not set, default them to the Port value in the CR
+	numOfAdditionalPorts := len(cr.GetService().GetPorts())
+	for i := 0; i < numOfAdditionalPorts; i++ {
+		if cr.Spec.Service.Ports[i].TargetPort.String() == "0" {
+			cr.Spec.Service.Ports[i].TargetPort = intstr.FromInt(int(cr.Spec.Service.Ports[i].Port))
+		}
+	}
 }
 
 // GetLabels returns set of labels to be added to all resources

--- a/bundle/tests/scorecard/kuttl/service-types/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/00-assert.yaml
@@ -1,0 +1,38 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps.openliberty.io/v1beta2
+kind: OpenLibertyApplication
+metadata:
+  name: service-types-lib
+status:
+  binding:
+    name: service-types-lib-expose-binding
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-types-lib
+spec:
+  ports:
+    - name: 9080-tcp
+      protocol: TCP
+      port: 9080
+      targetPort: 9080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: service-types-lib-expose-binding
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service-types-lib
+status:
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/service-types/00-default-service.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/00-default-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps.openliberty.io/v1beta2
+kind: OpenLibertyApplication
+metadata:
+  name: service-types-lib
+spec:
+  # Add fields here
+  applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
+  replicas: 1
+  service:
+    bindable: true

--- a/bundle/tests/scorecard/kuttl/service-types/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/01-assert.yaml
@@ -1,0 +1,44 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps.openliberty.io/v1beta2
+kind: OpenLibertyApplication
+metadata:
+  name: service-types-lib
+status:
+  binding:
+    name: service-types-lib-expose-binding
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    name: ClusterIPService
+  name: service-types-lib
+spec:
+  ports:
+    - name: 8080-tcp
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+    - name: test-port1
+      protocol: TCP
+      port: 8081
+      targetPort: 8082
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: service-types-lib-expose-binding
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service-types-lib
+status:
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/service-types/01-clusterip-service.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/01-clusterip-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps.openliberty.io/v1beta2
+kind: OpenLibertyApplication
+metadata:
+  name: service-types-lib
+spec:
+  # Add fields here
+  applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
+  replicas: 1
+  service:
+    bindable: true
+    port: 8080
+    ports:
+      - name: test-port1
+        port: 8081
+        protocol: TCP
+        targetPort: 8082
+    annotations:
+      name: ClusterIPService

--- a/bundle/tests/scorecard/kuttl/service-types/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/02-assert.yaml
@@ -1,0 +1,40 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps.openliberty.io/v1beta2
+kind: OpenLibertyApplication
+metadata:
+  name: service-types-lib
+status:
+  binding:
+    name: service-types-lib-expose-binding
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    name: ClusterIPService
+  name: service-types-lib
+spec:
+  ports:
+    - name: 8080-tcp
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: service-types-lib-expose-binding
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service-types-lib
+status:
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/service-types/02-remove-ports.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/02-remove-ports.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps.openliberty.io/v1beta2
+kind: OpenLibertyApplication
+metadata:
+  name: service-types-lib
+spec:
+  # Add fields here
+  applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
+  replicas: 1
+  service:
+    bindable: true
+    port: 8080
+    ports:
+    annotations:
+      name: ClusterIPService

--- a/bundle/tests/scorecard/kuttl/service-types/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/03-assert.yaml
@@ -1,0 +1,68 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps.openliberty.io/v1beta2
+kind: OpenLibertyApplication
+metadata:
+  name: service-types-lib
+status:
+  binding:
+    name: service-types-lib-expose-binding
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    name: ClusterIPService
+  name: service-types-lib
+spec:
+  ports:
+    - name: 8080-tcp
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+    - name: test-port1
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+    - name: test-port2
+      protocol: TCP
+      port: 8082
+      targetPort: 8083
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: service-types-lib-expose-binding
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service-types-lib
+status:
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1
+---
+apiVersion: apps.openliberty.io/v1beta2
+kind: OpenLibertyApplication
+metadata:
+  name: service-types-lib
+spec:
+  service:
+    bindable: true
+    port: 8080
+    ports:
+      - name: test-port1
+        port: 8081
+        protocol: TCP
+        targetPort: 8081
+      - name: test-port2
+        port: 8082
+        protocol: TCP
+        targetPort: 8083
+    annotations:
+      name: ClusterIPService

--- a/bundle/tests/scorecard/kuttl/service-types/03-clusterip-services.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/03-clusterip-services.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps.openliberty.io/v1beta2
+kind: OpenLibertyApplication
+metadata:
+  name: service-types-lib
+spec:
+  # Add fields here
+  applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
+  replicas: 1
+  service:
+    bindable: true
+    port: 8080
+    ports:
+      - name: test-port1
+        port: 8081
+        protocol: TCP
+      - name: test-port2
+        port: 8082
+        protocol: TCP
+        targetPort: 8083
+    annotations:
+      name: ClusterIPService

--- a/bundle/tests/scorecard/kuttl/service-types/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/04-assert.yaml
@@ -1,0 +1,44 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps.openliberty.io/v1beta2
+kind: OpenLibertyApplication
+metadata:
+  name: service-types-lib
+status:
+  binding:
+    name: service-types-lib-expose-binding
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-types-lib
+  annotations:
+    name: LoadBalancerService
+spec:
+  ports:
+    - name: test-port
+      protocol: TCP
+      port: 8082
+      targetPort: 8083
+    - name: test-port1
+      protocol: TCP
+      port: 8081
+      targetPort: 8083
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: service-types-lib-expose-binding
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service-types-lib
+status:
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/service-types/04-loadbalancer-service.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/04-loadbalancer-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps.openliberty.io/v1beta2
+kind: OpenLibertyApplication
+metadata:
+  name: service-types-lib
+spec:
+  # Add fields here
+  applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
+  replicas: 1
+  service:
+    bindable: true
+    port: 8082
+    portName: test-port
+    targetPort: 8083
+    ports:
+      - name: test-port1
+        port: 8081
+        protocol: TCP
+        targetPort: 8083
+    type: LoadBalancer
+    annotations:
+      name: LoadBalancerService

--- a/bundle/tests/scorecard/kuttl/service-types/05-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/05-assert.yaml
@@ -1,0 +1,44 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps.openliberty.io/v1beta2
+kind: OpenLibertyApplication
+metadata:
+  name: service-types-lib
+status:
+  binding:
+    name: service-types-lib-expose-binding
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-types-lib
+  annotations:
+    name: LoadBalancerService
+spec:
+  ports:
+    - name: 8082-tcp
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: test-port1
+      protocol: TCP
+      port: 8081
+      targetPort: 8083
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: service-types-lib-expose-binding
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service-types-lib
+status:
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/service-types/05-remove-portname-targetport.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/05-remove-portname-targetport.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps.openliberty.io/v1beta2
+kind: OpenLibertyApplication
+metadata:
+  name: service-types-lib
+spec:
+  # Add fields here
+  applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
+  replicas: 1
+  service:
+    bindable: true
+    port: 8082
+    portName:
+    targetPort:
+    ports:
+      - name: test-port1
+        port: 8081
+        protocol: TCP
+        targetPort: 8083
+    type: LoadBalancer
+    annotations:
+      name: LoadBalancerService

--- a/bundle/tests/scorecard/kuttl/service-types/06-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/06-assert.yaml
@@ -1,0 +1,49 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps.openliberty.io/v1beta2
+kind: OpenLibertyApplication
+metadata:
+  name: service-types-lib
+status:
+  binding:
+    name: service-types-lib-expose-binding
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-types-lib
+  annotations:
+    name: NodePort
+spec:
+  ports:
+    - name: test-port
+      protocol: TCP
+      port: 8080
+      targetPort: 8081
+      nodePort: 30932
+    - name: test-port1
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: test-port2
+      port: 8083
+      protocol: TCP
+      targetPort: 8083
+  type: NodePort
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: service-types-lib-expose-binding
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service-types-lib
+status:
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/service-types/06-nodeport-service.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/06-nodeport-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps.openliberty.io/v1beta2
+kind: OpenLibertyApplication
+metadata:
+  name: service-types-lib
+spec:
+  # Add fields here
+  applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
+  replicas: 1
+  service:
+    bindable: true
+    port: 8080
+    portName: test-port
+    targetPort: 8081
+    ports:
+      - name: test-port1
+        port: 8082
+        protocol: TCP
+      - name: test-port2
+        port: 8083
+        protocol: TCP
+    type: NodePort
+    nodePort: 30932
+    annotations:
+      name: NodePort

--- a/bundle/tests/scorecard/kuttl/service-types/07-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/07-assert.yaml
@@ -1,0 +1,49 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps.openliberty.io/v1beta2
+kind: OpenLibertyApplication
+metadata:
+  name: service-types-lib
+status:
+  binding:
+    name: service-types-lib-expose-binding
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-types-lib
+  annotations:
+    name: NodePort
+spec:
+  ports:
+    - name: test-port
+      protocol: TCP
+      port: 8080
+      targetPort: 8081
+      nodePort: 30932
+    - name: test-port1
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: test-port2
+      port: 8083
+      protocol: TCP
+      targetPort: 8083
+  type: NodePort
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: service-types-lib-expose-binding
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service-types-lib
+status:
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/service-types/07-remove-nodeport.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/07-remove-nodeport.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps.openliberty.io/v1beta2
+kind: OpenLibertyApplication
+metadata:
+  name: service-types-lib
+spec:
+  # Add fields here
+  applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
+  replicas: 1
+  service:
+    bindable: true
+    port: 8080
+    portName: test-port
+    targetPort: 8081
+    ports:
+      - name: test-port1
+        port: 8082
+        protocol: TCP
+      - name: test-port2
+        port: 8083
+        protocol: TCP
+    type: NodePort
+    nodePort:
+    annotations:
+      name: NodePort

--- a/bundle/tests/scorecard/kuttl/service-types/08-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/08-assert.yaml
@@ -1,0 +1,48 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps.openliberty.io/v1beta2
+kind: OpenLibertyApplication
+metadata:
+  name: service-types-lib
+status:
+  binding:
+    name: service-types-lib-expose-binding
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-types-lib
+  annotations:
+    name: NodePort
+spec:
+  ports:
+    - name: test-port
+      protocol: TCP
+      port: 8080
+      targetPort: 8081
+    - name: test-port1
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: test-port2
+      port: 8083
+      protocol: TCP
+      targetPort: 8083
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: service-types-lib-expose-binding
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service-types-lib
+status:
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/service-types/08-error.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/08-error.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-types-lib
+  annotations:
+    name: NodePort
+spec:
+  ports:
+    - name: test-port
+      protocol: TCP
+      port: 8080
+      targetPort: 8081
+      nodePort: 30932

--- a/bundle/tests/scorecard/kuttl/service-types/08-remove-type.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/08-remove-type.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps.openliberty.io/v1beta2
+kind: OpenLibertyApplication
+metadata:
+  name: service-types-lib
+spec:
+  # Add fields here
+  applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
+  replicas: 1
+  service:
+    bindable: true
+    port: 8080
+    portName: test-port
+    targetPort: 8081
+    ports:
+      - name: test-port1
+        port: 8082
+        protocol: TCP
+      - name: test-port2
+        port: 8083
+        protocol: TCP
+    type:
+    nodePort:
+    annotations:
+      name: NodePort

--- a/config/rbac/kuttl-rbac.yaml
+++ b/config/rbac/kuttl-rbac.yaml
@@ -42,6 +42,14 @@ rules:
   - get
   - list
 - apiGroups:
+    - ""
+  resources:
+    - services
+  verbs:
+    - get
+    - list
+    - patch
+- apiGroups:
   - apps
   resources:
   - deployments


### PR DESCRIPTION
Signed-off-by: Jason Yong <jason_yong@uk.ibm.com>

**What this PR does / why we need it?**:

- If its not defined, sets the targetport value to be the same as the port value in the CR
- Adds service-types tests

