### PR TITLE
Use image sha for sample image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,7 @@ endef
 
 .PHONY: bundle
 bundle: manifests setup kustomize ## Generate bundle manifests and metadata, then validate generated files.
+	scripts/update-sample.sh
 	sed -i.bak "s,IMAGE,${IMG},g;s,CREATEDAT,${CREATEDAT},g" config/manifests/patches/csvAnnotations.yaml
 	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)

--- a/bundle/manifests/open-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/open-liberty.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
             "name": "openliberty-app-sample"
           },
           "spec": {
-            "applicationImage": "icr.io/appcafe/open-liberty/samples/getting-started",
+            "applicationImage": "icr.io/appcafe/open-liberty/samples/getting-started@sha256:60ca13dd15d5dd583a594436d3568fc69fc7a58081dc40885dc4d2b16a6e4c69",
             "expose": true,
             "replicas": 1,
             "service": {
@@ -51,7 +51,7 @@ metadata:
     categories: Application Runtime
     certified: "true"
     containerImage: openliberty/operator:daily
-    createdAt: "2023-01-25T12:02:56Z"
+    createdAt: "2023-03-08T16:23:29Z"
     description: Deploy and manage applications running on Liberty
     operators.operatorframework.io/builder: operator-sdk-v1.6.1+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/config/samples/apps.openliberty.io_v1beta2_openlibertyapplications.yaml
+++ b/config/samples/apps.openliberty.io_v1beta2_openlibertyapplications.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openliberty-app-sample
 spec:
   # Add fields here
-  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started
+  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started@sha256:60ca13dd15d5dd583a594436d3568fc69fc7a58081dc40885dc4d2b16a6e4c69
   expose: true
   replicas: 1
   service:

--- a/scripts/update-sample.sh
+++ b/scripts/update-sample.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script fetches the sha256 for the latest version of the open liberty getting started container
+# image, and then edits the sample deployment and the csv for the operator, and inserts the tag
+
+if ! skopeo -v ; then
+  echo "Skopeo is not installed. Sample sha will not be updated"
+  exit
+fi
+
+echo "Editing sample tag"
+SHA=$(skopeo inspect docker://icr.io/appcafe/open-liberty/samples/getting-started:latest | jq '.Digest'| sed -e 's/"//g')
+if [ -z $SHA ]
+then
+  echo "Couldn't find latest SHA for sample image"
+  exit
+fi
+
+echo "sha is $SHA"
+
+files=" 
+config/samples/apps.openliberty.io_v1beta2_openlibertyapplications.yaml
+"
+
+for file in $files 
+do
+  sed -i.bak "s,getting-started@sha256:[a-zA-Z0-9]*,getting-started@$SHA," $file
+  rm $file.bak
+done
+


### PR DESCRIPTION
The RedHat certification requires that images are referenced by sha. Add a sha for the sample image, and also add a script to update the sha when 'make bundle' is run

This is the OLO portion of WASdev/websphere-liberty-operator#214