### PR TITLE
Update RCO module to include knative and operator configmap label updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OpenLiberty/open-liberty-operator
 go 1.19
 
 require (
-	github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230412203016-e85b860707eb
+	github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230421190839-08dca6236514
 	github.com/go-logr/logr v1.2.2
 	github.com/openshift/api v0.0.0-20220414050251-a83e6f8f1d50
 	github.com/openshift/library-go v0.0.0-20220630204433-c71d40c7de49

--- a/go.sum
+++ b/go.sum
@@ -67,12 +67,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
-github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230412141319-d54cc063ce93 h1:JwulV/nBPgjU9ECo3hOo5gxu3HDv9DuFFJcCddvAF7U=
-github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230412141319-d54cc063ce93/go.mod h1:JsX0ioxZzA0yM1Sxg/1QKLg9dGqDXYvGZ+WwiQrMoxQ=
-github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230412184305-c2ed6d367949 h1:8r1o7X9bTKeugtS9W7WS4aLzBQHDRzP9vsWjbmaQRnI=
-github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230412184305-c2ed6d367949/go.mod h1:JsX0ioxZzA0yM1Sxg/1QKLg9dGqDXYvGZ+WwiQrMoxQ=
-github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230412203016-e85b860707eb h1:eOWYL3/U31qjZvxSOFGZUe0nHdh3o6eT5Of+lyJv12I=
-github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230412203016-e85b860707eb/go.mod h1:JsX0ioxZzA0yM1Sxg/1QKLg9dGqDXYvGZ+WwiQrMoxQ=
+github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230421190839-08dca6236514 h1:ZSKbBVQH7C4PwfWzgG1s5m5tZA7N7MCR6ycyxoKfV+Q=
+github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230421190839-08dca6236514/go.mod h1:JsX0ioxZzA0yM1Sxg/1QKLg9dGqDXYvGZ+WwiQrMoxQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Set the security context on Knative Service (user specified or the default - the default matches what's set by Knative itself otherwise)
- Knative changed the label used to control visibility of route (adding the new label for now, we could remove the old label in the future if it's 100% not needed) - PR for https://github.com/application-stacks/runtime-component-operator/issues/515
- Always use utils method to create controller configmap (fix for https://github.com/application-stacks/runtime-component-operator/issues/506)
**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
