### PR TITLE
Replace default namespace to open-liberty for kustomize artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,8 @@ endif
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:crdVersions=v1,generateEmbeddedObjectMeta=true"
 
-# Produce files under deploy/kustomize/daily with default namespace
-KUSTOMIZE_NAMESPACE = default
+# Produce files under deploy/kustomize/daily with open-liberty namespace
+KUSTOMIZE_NAMESPACE = open-liberty
 KUSTOMIZE_IMG = icr.io/appcafe/open-liberty-operator:daily
 
 # Use docker if available. Otherwise default to podman. 

--- a/config/kustomize/operator/kustomization.yaml
+++ b/config/kustomize/operator/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 - ../../manager
 
 # Adds namespace to all resources.
-namespace: default
+namespace: open-liberty
 namePrefix: olo-
 
 # Labels to add to all resources and selectors.

--- a/config/kustomize/roles/kustomization.yaml
+++ b/config/kustomize/roles/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 - ../../rbac
 
 # Adds namespace to all resources.
-namespace: default
+namespace: open-liberty
 namePrefix: olo-
 
 # Labels to add to all resources and selectors.

--- a/internal/deploy/kustomize/1.2.0/README.adoc
+++ b/internal/deploy/kustomize/1.2.0/README.adoc
@@ -1,48 +1,47 @@
 = Installing the Open Liberty Operator using kustomize
 
-This directory contains kustomize files that can be used to install the operator
-in your cluster in various different configurations, and also some example overlays
-which show how the installation can be customized.
+This directory contains configuration files that helps installing the Open Liberty operator
+using `kustomize` with the Kubernetes command-line interface (CLI) (`kubectl`). These configurations
+are useful when the cluster is not a Red Hat® OpenShift® Container Platform cluster or when
+Operator Lifecycle Manager is not being used.
 
-== Install and watch own namespace
+== Installing and watching own namespace
 
 === base
-The simplest configuration will install the operator into the 'default' namespace, and the operator
-will watch for Open Liberty custom resource instances only in its own namespace. To install, run:
-`kubectl create -k base`
-and to uninstall, run:
-`kubectl delete -k base`
+The base configuration installs the operator into the 'open-liberty' namespace,
+and the operator watches for Open Liberty custom resource instances only in its own namespace.
+Create a namespace called 'open-liberty' for the operator.
+To install, run: `kubectl create -k base` and to uninstall, run: `kubectl delete -k base`
 
 === examples/watch-own-namespace
-This example overlay demonstrates how to modify the base configuration to install/watch a
-namespace other than 'default'. The example installs the operator to a namespace called
-'olo-ns' which should already exist. To install, run `kubectl create -k examples/watch-own-namespace`
+This example overlay demonstrates how to modify the base configuration to install the operator and have it
+watch a namespace other than 'open-liberty'. Create a namespace called 'olo-ns' for the operator.
+To install the operator into the 'olo-ns' namespace, run: `kubectl create -k examples/watch-own-namespace`
 
-== Install and watch another namespace
+== Installing and watching another namespace
 
 === overlays/watch-another-namespace
 This overlay installs the operator into the namespace 'olo-ns', but configures it to
-watch for Open Liberty custom resource instances in a different namespace called 'olo-watched-ns'. As
-this overlay install resources into two different namespaces, the namespace must not be specified
-in the kustomize.yaml file. To install, run `kubectl create -k overlays/watch-another-namespace`
+watch for Open Liberty custom resource instances in a different namespace called 'olo-watched-ns'.
+Because this overlay installs resources into two different namespaces, the namespace must not be specified
+in the kustomize.yaml file. To install, run:  `kubectl create -k overlays/watch-another-namespace`
 
 === examples/watch-another-namespace
-This example overlay builds on the previous one, but demonstrates how to change the
-install and watched namespaces. In this case, the operator is installed into 'olo-ns2'
-and it will watch for resources in 'olo-watched-ns2'. To install run `kubectl create -k
+This example overlay builds on the previous example, but demonstrates how to change
+the install and watched namespaces. In this case, the operator is installed into 'olo-ns2'
+and watches for resources in 'olo-watched-ns2'. To install run: `kubectl create -k
 examples/watch-another-namespace`
 
-== Install and watch all namespaces
+== Installing and watching all namespaces
 
 === overlays/watch-all-namespaces
-This overlay installs the operator into the default namespace, but configures it
-to watch for Open Liberty custom resource instances in any namespace. Compared to the base,
-this requires additional ClusterRoles and ClusterRoleBindings. To install run:
-`kubectl create -k overlays/watch-all-namespaces`
+This overlay installs the operator into the 'open-liberty' namespace,
+but configures it to watch for Open Liberty custom resource instances in any namespaces.
+Compared to the base configuration, this overlay requires additional ClusterRoles and ClusterRoleBindings.
+To install, run: `kubectl create -k overlays/watch-all-namespaces`
 
 === examples/watch-all-namespaces
-This example overlay builds on the previous one, and demonstrates how to change
-which namespace the operator is installed into. In this example, the operator
-is installed into a namespace called 'olo-ns', and will still watch for
-Open Liberty custom resource instances in any namespace. To install, run:
-`kubectl create -k examples/watch-all-namespaces`
+This example overlay builds on the previous example and demonstrates how to change
+the namespace that the operator installs into. In this example, the operator installs
+into a namespace that is called 'olo-ns' and watches for Open Liberty custom resource
+instances in any namespaces. To install, run: `kubectl create -k examples/watch-all-namespaces`

--- a/internal/deploy/kustomize/1.2.0/base/kustomization.yaml
+++ b/internal/deploy/kustomize/1.2.0/base/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: default
+namespace: open-liberty
 
 resources:
   - open-liberty-crd.yaml

--- a/internal/deploy/kustomize/1.2.0/base/open-liberty-operator.yaml
+++ b/internal/deploy/kustomize/1.2.0/base/open-liberty-operator.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/name: open-liberty-operator
     control-plane: controller-manager
   name: olo-controller-manager
-  namespace: default
+  namespace: open-liberty
 spec:
   replicas: 1
   selector:

--- a/internal/deploy/kustomize/1.2.0/base/open-liberty-roles.yaml
+++ b/internal/deploy/kustomize/1.2.0/base/open-liberty-roles.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: open-liberty-operator
     app.kubernetes.io/name: open-liberty-operator
   name: olo-controller-manager
-  namespace: default
+  namespace: open-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/instance: open-liberty-operator
     app.kubernetes.io/name: open-liberty-operator
   name: olo-leader-election-role
-  namespace: default
+  namespace: open-liberty
 rules:
 - apiGroups:
   - ""
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/instance: open-liberty-operator
     app.kubernetes.io/name: open-liberty-operator
   name: olo-manager-role
-  namespace: default
+  namespace: open-liberty
 rules:
 - apiGroups:
   - apps
@@ -231,7 +231,7 @@ metadata:
     app.kubernetes.io/instance: open-liberty-operator
     app.kubernetes.io/name: open-liberty-operator
   name: olo-leader-election-rolebinding
-  namespace: default
+  namespace: open-liberty
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -239,7 +239,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: olo-controller-manager
-  namespace: default
+  namespace: open-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -248,7 +248,7 @@ metadata:
     app.kubernetes.io/instance: open-liberty-operator
     app.kubernetes.io/name: open-liberty-operator
   name: olo-manager-rolebinding
-  namespace: default
+  namespace: open-liberty
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -256,4 +256,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: olo-controller-manager
-  namespace: default
+  namespace: open-liberty

--- a/internal/deploy/kustomize/1.2.0/overlays/watch-all-namespaces/cluster-roles.yaml
+++ b/internal/deploy/kustomize/1.2.0/overlays/watch-all-namespaces/cluster-roles.yaml
@@ -12,7 +12,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: olo-controller-manager
-  namespace: default
+  namespace: open-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -28,7 +28,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: olo-controller-manager
-  namespace: default
+  namespace: open-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/internal/deploy/kustomize/1.2.0/overlays/watch-all-namespaces/kustomization.yaml
+++ b/internal/deploy/kustomize/1.2.0/overlays/watch-all-namespaces/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: default
+namespace: open-liberty
 
 bases:
 - ../../base

--- a/internal/deploy/kustomize/1.2.0/overlays/watch-all-namespaces/olo-all-namespaces.yaml
+++ b/internal/deploy/kustomize/1.2.0/overlays/watch-all-namespaces/olo-all-namespaces.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: olo-controller-manager
+  namespace: open-liberty
 spec:
   template:
     spec:

--- a/internal/deploy/kustomize/1.2.0/overlays/watch-another-namespace/olo-ns/olo-deployment.yaml
+++ b/internal/deploy/kustomize/1.2.0/overlays/watch-another-namespace/olo-ns/olo-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: olo-controller-manager
-  namespace: default
+  namespace: open-liberty
 spec:
   template:
     spec:

--- a/internal/deploy/kustomize/1.2.0/overlays/watch-another-namespace/olo-ns/olo-roles.yaml
+++ b/internal/deploy/kustomize/1.2.0/overlays/watch-another-namespace/olo-ns/olo-roles.yaml
@@ -2,32 +2,32 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: olo-leader-election-role
-  namespace: default
+  namespace: open-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: olo-manager-role
-  namespace: default
+  namespace: open-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: olo-leader-election-rolebinding
-  namespace: default
+  namespace: open-liberty
 subjects:
 - kind: ServiceAccount
   name: olo-controller-manager
-  namespace: default
+  namespace: open-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: olo-manager-rolebinding
-  namespace: default
+  namespace: open-liberty
 subjects:
 - kind: ServiceAccount
   name: olo-controller-manager
-  namespace: default
+  namespace: open-liberty
 
 

--- a/internal/deploy/kustomize/1.2.0/overlays/watch-another-namespace/olo-ns/olo-sa.yaml
+++ b/internal/deploy/kustomize/1.2.0/overlays/watch-another-namespace/olo-ns/olo-sa.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: olo-controller-manager
-  namespace: default
+  namespace: open-liberty

--- a/internal/deploy/kustomize/daily/README.adoc
+++ b/internal/deploy/kustomize/daily/README.adoc
@@ -1,48 +1,47 @@
 = Installing the Open Liberty Operator using kustomize
 
-This directory contains kustomize files that can be used to install the operator
-in your cluster in various different configurations, and also some example overlays
-which show how the installation can be customized.
+This directory contains configuration files that helps installing the Open Liberty operator
+using `kustomize` with the Kubernetes command-line interface (CLI) (`kubectl`). These configurations
+are useful when the cluster is not a Red Hat® OpenShift® Container Platform cluster or when
+Operator Lifecycle Manager is not being used.
 
-== Install and watch own namespace
+== Installing and watching own namespace
 
 === base
-The simplest configuration will install the operator into the 'default' namespace, and the operator
-will watch for Open Liberty custom resource instances only in its own namespace. To install, run:
-`kubectl create -k base`
-and to uninstall, run:
-`kubectl delete -k base`
+The base configuration installs the operator into the 'open-liberty' namespace,
+and the operator watches for Open Liberty custom resource instances only in its own namespace.
+Create a namespace called 'open-liberty' for the operator.
+To install, run: `kubectl create -k base` and to uninstall, run: `kubectl delete -k base`
 
 === examples/watch-own-namespace
-This example overlay demonstrates how to modify the base configuration to install/watch a
-namespace other than 'default'. The example installs the operator to a namespace called
-'olo-ns' which should already exist. To install, run `kubectl create -k examples/watch-own-namespace`
+This example overlay demonstrates how to modify the base configuration to install the operator and have it
+watch a namespace other than 'open-liberty'. Create a namespace called 'olo-ns' for the operator.
+To install the operator into the 'olo-ns' namespace, run: `kubectl create -k examples/watch-own-namespace`
 
-== Install and watch another namespace
+== Installing and watching another namespace
 
 === overlays/watch-another-namespace
 This overlay installs the operator into the namespace 'olo-ns', but configures it to
-watch for Open Liberty custom resource instances in a different namespace called 'olo-watched-ns'. As
-this overlay install resources into two different namespaces, the namespace must not be specified
-in the kustomize.yaml file. To install, run `kubectl create -k overlays/watch-another-namespace`
+watch for Open Liberty custom resource instances in a different namespace called 'olo-watched-ns'.
+Because this overlay installs resources into two different namespaces, the namespace must not be specified
+in the kustomize.yaml file. To install, run:  `kubectl create -k overlays/watch-another-namespace`
 
 === examples/watch-another-namespace
-This example overlay builds on the previous one, but demonstrates how to change the
-install and watched namespaces. In this case, the operator is installed into 'olo-ns2'
-and it will watch for resources in 'olo-watched-ns2'. To install run `kubectl create -k
+This example overlay builds on the previous example, but demonstrates how to change
+the install and watched namespaces. In this case, the operator is installed into 'olo-ns2'
+and watches for resources in 'olo-watched-ns2'. To install run: `kubectl create -k
 examples/watch-another-namespace`
 
-== Install and watch all namespaces
+== Installing and watching all namespaces
 
 === overlays/watch-all-namespaces
-This overlay installs the operator into the default namespace, but configures it
-to watch for Open Liberty custom resource instances in any namespace. Compared to the base,
-this requires additional ClusterRoles and ClusterRoleBindings. To install run:
-`kubectl create -k overlays/watch-all-namespaces`
+This overlay installs the operator into the 'open-liberty' namespace,
+but configures it to watch for Open Liberty custom resource instances in any namespaces.
+Compared to the base configuration, this overlay requires additional ClusterRoles and ClusterRoleBindings.
+To install, run: `kubectl create -k overlays/watch-all-namespaces`
 
 === examples/watch-all-namespaces
-This example overlay builds on the previous one, and demonstrates how to change
-which namespace the operator is installed into. In this example, the operator
-is installed into a namespace called 'olo-ns', and will still watch for
-Open Liberty custom resource instances in any namespace. To install, run:
-`kubectl create -k examples/watch-all-namespaces`
+This example overlay builds on the previous example and demonstrates how to change
+the namespace that the operator installs into. In this example, the operator installs
+into a namespace that is called 'olo-ns' and watches for Open Liberty custom resource
+instances in any namespaces. To install, run: `kubectl create -k examples/watch-all-namespaces`

--- a/internal/deploy/kustomize/daily/base/kustomization.yaml
+++ b/internal/deploy/kustomize/daily/base/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: default
+namespace: open-liberty
 
 resources:
   - open-liberty-crd.yaml

--- a/internal/deploy/kustomize/daily/base/open-liberty-operator.yaml
+++ b/internal/deploy/kustomize/daily/base/open-liberty-operator.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/name: open-liberty-operator
     control-plane: controller-manager
   name: olo-controller-manager
-  namespace: default
+  namespace: open-liberty
 spec:
   replicas: 1
   selector:

--- a/internal/deploy/kustomize/daily/base/open-liberty-roles.yaml
+++ b/internal/deploy/kustomize/daily/base/open-liberty-roles.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: open-liberty-operator
     app.kubernetes.io/name: open-liberty-operator
   name: olo-controller-manager
-  namespace: default
+  namespace: open-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/instance: open-liberty-operator
     app.kubernetes.io/name: open-liberty-operator
   name: olo-leader-election-role
-  namespace: default
+  namespace: open-liberty
 rules:
 - apiGroups:
   - ""
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/instance: open-liberty-operator
     app.kubernetes.io/name: open-liberty-operator
   name: olo-manager-role
-  namespace: default
+  namespace: open-liberty
 rules:
 - apiGroups:
   - apps
@@ -231,7 +231,7 @@ metadata:
     app.kubernetes.io/instance: open-liberty-operator
     app.kubernetes.io/name: open-liberty-operator
   name: olo-leader-election-rolebinding
-  namespace: default
+  namespace: open-liberty
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -239,7 +239,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: olo-controller-manager
-  namespace: default
+  namespace: open-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -248,7 +248,7 @@ metadata:
     app.kubernetes.io/instance: open-liberty-operator
     app.kubernetes.io/name: open-liberty-operator
   name: olo-manager-rolebinding
-  namespace: default
+  namespace: open-liberty
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -256,4 +256,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: olo-controller-manager
-  namespace: default
+  namespace: open-liberty

--- a/internal/deploy/kustomize/daily/overlays/watch-all-namespaces/cluster-roles.yaml
+++ b/internal/deploy/kustomize/daily/overlays/watch-all-namespaces/cluster-roles.yaml
@@ -12,7 +12,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: olo-controller-manager
-  namespace: default
+  namespace: open-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -28,7 +28,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: olo-controller-manager
-  namespace: default
+  namespace: open-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/internal/deploy/kustomize/daily/overlays/watch-all-namespaces/kustomization.yaml
+++ b/internal/deploy/kustomize/daily/overlays/watch-all-namespaces/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: default
+namespace: open-liberty
 
 bases:
 - ../../base

--- a/internal/deploy/kustomize/daily/overlays/watch-all-namespaces/olo-all-namespaces.yaml
+++ b/internal/deploy/kustomize/daily/overlays/watch-all-namespaces/olo-all-namespaces.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: olo-controller-manager
+  namespace: open-liberty
 spec:
   template:
     spec:

--- a/internal/deploy/kustomize/daily/overlays/watch-another-namespace/olo-ns/olo-deployment.yaml
+++ b/internal/deploy/kustomize/daily/overlays/watch-another-namespace/olo-ns/olo-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: olo-controller-manager
-  namespace: default
+  namespace: open-liberty
 spec:
   template:
     spec:

--- a/internal/deploy/kustomize/daily/overlays/watch-another-namespace/olo-ns/olo-roles.yaml
+++ b/internal/deploy/kustomize/daily/overlays/watch-another-namespace/olo-ns/olo-roles.yaml
@@ -2,32 +2,32 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: olo-leader-election-role
-  namespace: default
+  namespace: open-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: olo-manager-role
-  namespace: default
+  namespace: open-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: olo-leader-election-rolebinding
-  namespace: default
+  namespace: open-liberty
 subjects:
 - kind: ServiceAccount
   name: olo-controller-manager
-  namespace: default
+  namespace: open-liberty
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: olo-manager-rolebinding
-  namespace: default
+  namespace: open-liberty
 subjects:
 - kind: ServiceAccount
   name: olo-controller-manager
-  namespace: default
+  namespace: open-liberty
 
 

--- a/internal/deploy/kustomize/daily/overlays/watch-another-namespace/olo-ns/olo-sa.yaml
+++ b/internal/deploy/kustomize/daily/overlays/watch-another-namespace/olo-ns/olo-sa.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: olo-controller-manager
-  namespace: default
+  namespace: open-liberty


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Avoid using default namespace, which throws permission errors
- Fix watch-all-namespaces
- Align with WebSphere Liberty doc

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Issue: https://github.com/OpenLiberty/open-liberty-operator/issues/415
