### PR TITLE
Kuttl test changes for multiarch

### DIFF
--- a/bundle/tests/scorecard/kuttl/probe/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/03-assert.yaml
@@ -43,8 +43,6 @@ spec:
           successThreshold: 1
           failureThreshold: 20
 status:
-# not checking readyReplicas or replicas while using icr.io/appcafe/open-liberty:full-java8-openj9-ubi 
-# as it uses different default ports. Replace with icr.io/appcafe/open-liberty/samples/getting-started once multiarch
-#  readyReplicas: 1
-#  replicas: 1
+  readyReplicas: 1
+  replicas: 1
   updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/probe/03-probe-defaults.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/03-probe-defaults.yaml
@@ -4,7 +4,7 @@ metadata:
   name: probes-liberty
 spec:
   # Add fields here
-  applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
+  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started
   manageTLS: false
   service:
     port: 9443

--- a/bundle/tests/scorecard/kuttl/probe/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/04-assert.yaml
@@ -43,8 +43,6 @@ spec:
             successThreshold: 1
             failureThreshold: 5
 status:
-# not checking readyReplicas or replicas while using icr.io/appcafe/open-liberty:full-java8-openj9-ubi 
-# as it uses different default ports. Replace with icr.io/appcafe/open-liberty/samples/getting-started once multiarc
-#  readyReplicas: 1
-#  replicas: 1
+  readyReplicas: 1
+  replicas: 1
   updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/probe/05-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/05-assert.yaml
@@ -23,8 +23,6 @@ spec:
             successThreshold: 1
             failureThreshold: 20
 status:
-# not checking readyReplicas or replicas while using icr.io/appcafe/open-liberty:full-java8-openj9-ubi 
-# as it uses different default ports. Replace with icr.io/appcafe/open-liberty/samples/getting-started once multiarc
-#  readyReplicas: 1
-#  replicas: 1
+  readyReplicas: 1
+  replicas: 1
   updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/storage/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/storage/03-assert.yaml
@@ -1,5 +1,3 @@
-# The RCO travis test cluster only has 1 usable storage class so the test just checks
-# that the statefulSet.storage.* configs are correctly set
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 timeout: 60
@@ -13,7 +11,7 @@ metadata:
 status:
   replicas: 1
   readyReplicas: 1
-#  updatedReplicas: 1
+  updatedReplicas: 1
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/bundle/tests/scorecard/kuttl/storage/05-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/storage/05-assert.yaml
@@ -1,5 +1,3 @@
-# The RCO travis test cluster only has 1 usable storage class so the test just checks
-# that the statefulSet.storage.* configs are correctly set
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 timeout: 60
@@ -10,8 +8,8 @@ metadata:
   name: storage-liberty
 status:
   replicas: 1
-#  readyReplicas: 1
-#  updatedReplicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Reverted changes make to kuttl e2e tests now that the getting started app is multiarch
- Updated storage tests now that it uses onepipeline
