### PR TITLE
Update skopeo command to return single digest

### DIFF
--- a/.one-pipeline-cd.yaml
+++ b/.one-pipeline-cd.yaml
@@ -23,7 +23,7 @@ setup:
       echo "${DIGEST}"
       echo "${APP}" | jq '.'
 
-      SAVED_DIGEST="$(skopeo inspect docker://$ARTIFACT | grep Digest | grep -o 'sha[^\"]*')"
+      SAVED_DIGEST="$(skopeo inspect docker://$ARTIFACT | jq '.Digest'| sed -e 's/"//g')"
       if [[ ${DIGEST} == ${SAVED_DIGEST} ]]; then
         echo "Image, $ARTIFACT, passes validation"
       else

--- a/.one-pipeline.yaml
+++ b/.one-pipeline.yaml
@@ -288,7 +288,7 @@ containerize:
     for i in "${tags[@]}"
     do
       IMAGE=$PIPELINE_REGISTRY/$PIPELINE_OPERATOR_IMAGE:$i
-      DIGEST="$(skopeo inspect docker://$IMAGE | grep Digest | grep -o 'sha[^\"]*')"
+      DIGEST="$(skopeo inspect docker://$IMAGE | jq '.Digest'| sed -e 's/"//g')"
       { ARCH="$(echo $i | grep -o '\(amd64\|s390x\|ppc64le\)$')" && TYPE="image"; } || { TYPE="manifest"; }
       if [[ "$TYPE" == "manifest" ]]; then
         echo "Saving artifact operator-$i type=$TYPE name=$IMAGE digest=$DIGEST"
@@ -299,13 +299,13 @@ containerize:
       fi
     done
     IMAGE=$PIPELINE_REGISTRY/$PIPELINE_OPERATOR_IMAGE-bundle:${RELEASE_TARGET}
-    DIGEST="$(skopeo inspect docker://$IMAGE | grep Digest | grep -o 'sha[^\"]*')"
+    DIGEST="$(skopeo inspect docker://$IMAGE | jq '.Digest'| sed -e 's/"//g')"
     echo "Saving artifact bundle-${RELEASE_TARGET} name=$IMAGE digest=$DIGEST"
     save_artifact bundle-${RELEASE_TARGET} type=image name="$IMAGE" "digest=$DIGEST"
     for i in "${tags[@]}"
     do
       IMAGE=$PIPELINE_REGISTRY/$PIPELINE_OPERATOR_IMAGE-catalog:$i
-      DIGEST="$(skopeo inspect docker://$IMAGE | grep Digest | grep -o 'sha[^\"]*')"
+      DIGEST="$(skopeo inspect docker://$IMAGE | jq '.Digest'| sed -e 's/"//g')"
       { ARCH="$(echo $i | grep -o '\(amd64\|s390x\|ppc64le\)$')" && TYPE="image"; } || { ARCH="amd64" && TYPE="manifest"; }
       if [[ "$TYPE" == "manifest" ]]; then
         echo "Saving artifact catalog-$i type=$TYPE name=$IMAGE digest=$DIGEST"
@@ -322,7 +322,7 @@ containerize:
     
     ## Perform lint
     IMAGE="${PIPELINE_REGISTRY}/${PIPELINE_OPERATOR_IMAGE}-bundle:${RELEASE_TARGET}"
-    DIGEST="$(skopeo inspect docker://$IMAGE | grep Digest | grep -o 'sha[^\"]*')"
+    DIGEST="$(skopeo inspect docker://$IMAGE | jq '.Digest'| sed -e 's/"//g')"
     BUNDLE_IMAGE_WITH_DIGEST="${IMAGE}@${DIGEST}"
     ./scripts/pipeline/static-linter-scan.sh --git-token $(get_env git-token) --bundle-image $BUNDLE_IMAGE_WITH_DIGEST --static-linter-version $(get_env static-linter-version)
 


### PR DESCRIPTION
**What this PR does / why we need it?**:

- skopeo started returning multiple sha values when using `| grep Digest | grep -o 'sha[^\"]*'` to filter the results.
Replaced with `| jq '.Digest'| sed -e 's/"//g'` to ensure only the digest is returned

