### PR TITLE
Remove test timeouts as the overall timeout is now longer

### DIFF
--- a/bundle/tests/scorecard/kind-kuttl/ingress-manage-tls/00-assert.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/ingress-manage-tls/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 # Check creation of CertManager certificates and secret
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/bundle/tests/scorecard/kind-kuttl/ingress-manage-tls/01-assert.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/ingress-manage-tls/01-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 kind: Deployment
 apiVersion: apps/v1
 metadata:

--- a/bundle/tests/scorecard/kind-kuttl/ingress-manage-tls/02-assert.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/ingress-manage-tls/02-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 # Verify that the deleted Certificate has been restored
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/bundle/tests/scorecard/kind-kuttl/ingress-manage-tls/03-assert.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/ingress-manage-tls/03-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 # Verify the pod template spec defaults and that secretName uses *-cm naming convention
 apiVersion: apps/v1
 kind: StatefulSet

--- a/bundle/tests/scorecard/kind-kuttl/ingress-manage-tls/04-assert.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/ingress-manage-tls/04-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/bundle/tests/scorecard/kind-kuttl/ingress-manage-tls/05-assert.yaml
+++ b/bundle/tests/scorecard/kind-kuttl/ingress-manage-tls/05-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 # Verify the pod template spec defaults and that secretName uses BYO secret
 apiVersion: apps/v1
 kind: StatefulSet

--- a/bundle/tests/scorecard/kuttl/auto1/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/auto1/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/auto1/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/auto1/01-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/auto1/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/auto1/02-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/auto1/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/auto1/03-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/auto1/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/auto1/04-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/auto2/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/auto2/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/auto3/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/auto3/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/auto3/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/auto3/01-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/auto3/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/auto3/02-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/basic/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/basic/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/basic/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/basic/01-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/deployment-strategy/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/deployment-strategy/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 90
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/deployment-strategy/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/deployment-strategy/01-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/deployment-strategy/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/deployment-strategy/02-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/deployment-strategy/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/deployment-strategy/03-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/deployment-strategy/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/deployment-strategy/04-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/env/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/env/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/bundle/tests/scorecard/kuttl/env/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/env/01-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/env/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/env/02-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/env/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/env/03-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/bundle/tests/scorecard/kuttl/env/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/env/04-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/bundle/tests/scorecard/kuttl/image-stream/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/image-stream/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 90
----
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:

--- a/bundle/tests/scorecard/kuttl/image-stream/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/image-stream/01-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 90
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/image-stream/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/image-stream/02-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 90
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/image-stream/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/image-stream/03-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 90
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/image-stream/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/image-stream/04-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 90
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/manage-tls/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/manage-tls/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 # Check creation of CertManager certificates and secret
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/bundle/tests/scorecard/kuttl/manage-tls/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/manage-tls/01-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 kind: Deployment
 apiVersion: apps/v1
 metadata:

--- a/bundle/tests/scorecard/kuttl/manage-tls/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/manage-tls/02-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 # Verify that the deleted Certificate has been restored
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/bundle/tests/scorecard/kuttl/manage-tls/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/manage-tls/03-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 # Verify the pod template spec defaults and that secretName uses *-ocp naming convention
 apiVersion: apps/v1
 kind: StatefulSet

--- a/bundle/tests/scorecard/kuttl/manage-tls/05-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/manage-tls/05-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 # Verify the pod template spec defaults and that secretName uses *-ocp naming convention
 apiVersion: apps/v1
 kind: Deployment

--- a/bundle/tests/scorecard/kuttl/manage-tls/06-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/manage-tls/06-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/manage-tls/07-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/manage-tls/07-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/bundle/tests/scorecard/kuttl/manage-tls/08-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/manage-tls/08-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 # Verify the pod template spec defaults and that secretName uses BYO secret
 apiVersion: apps/v1
 kind: Deployment

--- a/bundle/tests/scorecard/kuttl/monitor/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/monitor/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/monitor/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/monitor/01-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/monitor/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/monitor/02-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/network-policy-multiple-apps/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/network-policy-multiple-apps/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/bundle/tests/scorecard/kuttl/network-policy/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/network-policy/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/bundle/tests/scorecard/kuttl/network-policy/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/network-policy/01-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/bundle/tests/scorecard/kuttl/network-policy/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/network-policy/02-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/bundle/tests/scorecard/kuttl/network-policy/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/network-policy/03-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/bundle/tests/scorecard/kuttl/network-policy/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/network-policy/04-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/bundle/tests/scorecard/kuttl/network-policy/05-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/network-policy/05-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/bundle/tests/scorecard/kuttl/network-policy/06-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/network-policy/06-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/bundle/tests/scorecard/kuttl/network-policy/07-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/network-policy/07-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/bundle/tests/scorecard/kuttl/network-policy/08-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/network-policy/08-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/bundle/tests/scorecard/kuttl/network-policy/09-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/network-policy/09-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/bundle/tests/scorecard/kuttl/network-policy/10-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/network-policy/10-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/bundle/tests/scorecard/kuttl/network-policy/11-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/network-policy/11-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/bundle/tests/scorecard/kuttl/probe/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 120
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/probe/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/01-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 120
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/probe/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/02-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 120
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/probe/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/03-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 120
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/probe/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/04-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 120
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/probe/05-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/05-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 120
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/pullpolicy/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/pullpolicy/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 90
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/pullpolicy/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/pullpolicy/01-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 90
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/pullpolicy/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/pullpolicy/02-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 90
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/pullpolicy/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/pullpolicy/03-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 90
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/security-context/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/security-context/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 # Check the default security context
 apiVersion: apps/v1
 kind: Deployment

--- a/bundle/tests/scorecard/kuttl/security-context/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/security-context/01-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/security-context/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/security-context/02-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/security-context/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/security-context/03-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/security-context/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/security-context/04-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/semeru/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/semeru/00-assert.yaml
@@ -3,10 +3,6 @@
 # 2. Semeru service is create wtih the all correct default values.
 # 3. Application deployment is created with all correct default values (including certs and jitserver config properties being set)  
 
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 120
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/service-account-name/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-account-name/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/service-account-name/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-account-name/01-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/service-account-name/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-account-name/02-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/service-account-name/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-account-name/03-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/bundle/tests/scorecard/kuttl/service-account-name/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-account-name/04-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/bundle/tests/scorecard/kuttl/service-binding1/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-binding1/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps.openliberty.io/v1
 kind: OpenLibertyApplication
 metadata:

--- a/bundle/tests/scorecard/kuttl/service-binding1/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-binding1/01-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bundle/tests/scorecard/kuttl/service-binding2/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-binding2/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps.openliberty.io/v1
 kind: OpenLibertyApplication
 metadata:

--- a/bundle/tests/scorecard/kuttl/service-binding2/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-binding2/01-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bundle/tests/scorecard/kuttl/service-types/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps.openliberty.io/v1
 kind: OpenLibertyApplication
 metadata:

--- a/bundle/tests/scorecard/kuttl/service-types/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/01-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps.openliberty.io/v1
 kind: OpenLibertyApplication
 metadata:

--- a/bundle/tests/scorecard/kuttl/service-types/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/02-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps.openliberty.io/v1
 kind: OpenLibertyApplication
 metadata:

--- a/bundle/tests/scorecard/kuttl/service-types/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/03-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps.openliberty.io/v1
 kind: OpenLibertyApplication
 metadata:

--- a/bundle/tests/scorecard/kuttl/service-types/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/04-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps.openliberty.io/v1
 kind: OpenLibertyApplication
 metadata:

--- a/bundle/tests/scorecard/kuttl/service-types/05-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/05-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps.openliberty.io/v1
 kind: OpenLibertyApplication
 metadata:

--- a/bundle/tests/scorecard/kuttl/service-types/06-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/06-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps.openliberty.io/v1
 kind: OpenLibertyApplication
 metadata:

--- a/bundle/tests/scorecard/kuttl/service-types/07-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/service-types/07-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps.openliberty.io/v1
 kind: OpenLibertyApplication
 metadata:

--- a/bundle/tests/scorecard/kuttl/statefulset-strategy/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/statefulset-strategy/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 90
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/bundle/tests/scorecard/kuttl/statefulset-strategy/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/statefulset-strategy/01-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/bundle/tests/scorecard/kuttl/statefulset-strategy/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/statefulset-strategy/02-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/bundle/tests/scorecard/kuttl/storage/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/storage/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/bundle/tests/scorecard/kuttl/storage/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/storage/01-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bundle/tests/scorecard/kuttl/storage/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/storage/03-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/bundle/tests/scorecard/kuttl/storage/05-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/storage/05-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:


### PR DESCRIPTION
The default test step timeout in kuttl-test.yaml is now set to 150s. This means that tests which were setting a step timeout of 60s were actually less robust to timing issues.