### PR TITLE
Remove Appsody from bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,13 +31,6 @@ A clear and concise description of what you expected to happen (or insert a code
 
 <!--- Insert the output of `oc version` here -->
 
-* Appsody CLI version (if applicable):
-
-<!--- Insert the output of `appsody version`here -->
-
-* Appsody Stack (if applicable):
-
-
 ### Possible solution
 
 <!--- Only if you have suggestions on a fix for the bug -->


### PR DESCRIPTION
Removed references to appsody from bug template

**What this PR does / why we need it?**:
Appsody is dead so the bug template doesn't need to ask information about it.
