### PR TITLE
Latest version of utils from RCO to pick up prometeus fix

### DIFF
--- a/bundle/tests/scorecard/kuttl/monitor/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/monitor/02-assert.yaml
@@ -17,7 +17,7 @@ spec:
       app.kubernetes.io/instance: service-monitor-liberty
   endpoints:
   - path: "/path"
-    scheme: "HTTPS"
+    scheme: "https"
     port: 9443-tcp
     params:
       params:

--- a/bundle/tests/scorecard/kuttl/monitor/02-update-monitor.yaml
+++ b/bundle/tests/scorecard/kuttl/monitor/02-update-monitor.yaml
@@ -6,7 +6,7 @@ spec:
   monitoring:
     endpoints:
     - path: "/path"
-      scheme: "HTTPS"
+      scheme: "https"
       params:
         params:
         - "param1"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OpenLiberty/open-liberty-operator
 go 1.19
 
 require (
-	github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230421190839-08dca6236514
+	github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230613090743-bf7f8422094b
 	github.com/go-logr/logr v1.2.2
 	github.com/openshift/api v0.0.0-20220414050251-a83e6f8f1d50
 	github.com/openshift/library-go v0.0.0-20220630204433-c71d40c7de49

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
-github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230421190839-08dca6236514 h1:ZSKbBVQH7C4PwfWzgG1s5m5tZA7N7MCR6ycyxoKfV+Q=
-github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230421190839-08dca6236514/go.mod h1:JsX0ioxZzA0yM1Sxg/1QKLg9dGqDXYvGZ+WwiQrMoxQ=
+github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230613090743-bf7f8422094b h1:yW/ojzeZvNbwIb7sN5Kf6ofK3ao+u0gBvFMXBLl2mw4=
+github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20230613090743-bf7f8422094b/go.mod h1:JsX0ioxZzA0yM1Sxg/1QKLg9dGqDXYvGZ+WwiQrMoxQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=


### PR DESCRIPTION
Prometheus has added validation which checks that the scheme is either 'https' or 'http' (lowercase only)
