### PR TITLE
Update OLO version to 1.2.1 and update catalog base image and OPM versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ARG USER_ID=65532
 ARG GROUP_ID=65532
 
-ARG VERSION_LABEL=1.2.0
+ARG VERSION_LABEL=1.2.1
 ARG RELEASE_LABEL=XX
 ARG VCS_REF=0123456789012345678901234567890123456789
 ARG VCS_URL="https://github.com/OpenLiberty/open-liberty-operator"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.2.0
+VERSION ?= 1.2.1
 OPERATOR_SDK_RELEASE_VERSION ?= v1.24.0
 
 # CHANNELS define the bundle channels used in the bundle.

--- a/bundle/manifests/open-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/open-liberty.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
             "name": "openliberty-app-sample"
           },
           "spec": {
-            "applicationImage": "icr.io/appcafe/open-liberty/samples/getting-started@sha256:e22dd56a05e44618a10d275d3ff07a38eb364c0f04f86ffe9618d83dd5467860",
+            "applicationImage": "icr.io/appcafe/open-liberty/samples/getting-started@sha256:b0d658e07e656a8cb3b02bf7194f788f4456c7ffe9d3361f96ac2807045dad80",
             "expose": true,
             "manageTLS": true,
             "replicas": 1
@@ -51,7 +51,7 @@ metadata:
             "name": "openliberty-app-sample"
           },
           "spec": {
-            "applicationImage": "icr.io/appcafe/open-liberty/samples/getting-started@sha256:e22dd56a05e44618a10d275d3ff07a38eb364c0f04f86ffe9618d83dd5467860",
+            "applicationImage": "icr.io/appcafe/open-liberty/samples/getting-started@sha256:b0d658e07e656a8cb3b02bf7194f788f4456c7ffe9d3361f96ac2807045dad80",
             "expose": true,
             "replicas": 1,
             "service": {
@@ -91,7 +91,7 @@ metadata:
     categories: Application Runtime
     certified: "true"
     containerImage: icr.io/appcafe/open-liberty-operator:daily
-    createdAt: "2023-06-16T14:45:48Z"
+    createdAt: "2023-06-16T14:58:06Z"
     description: Deploy and manage containerized Liberty applications
     olm.skipRange: '>=0.8.0 <1.2.1'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
@@ -1083,7 +1083,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: RELATED_IMAGE_LIBERTY_SAMPLE_APP
-                  value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e22dd56a05e44618a10d275d3ff07a38eb364c0f04f86ffe9618d83dd5467860
+                  value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:b0d658e07e656a8cb3b02bf7194f788f4456c7ffe9d3361f96ac2807045dad80
                 image: icr.io/appcafe/open-liberty-operator:daily
                 livenessProbe:
                   failureThreshold: 3
@@ -1361,6 +1361,6 @@ spec:
   provider:
     name: IBM
   relatedImages:
-  - image: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e22dd56a05e44618a10d275d3ff07a38eb364c0f04f86ffe9618d83dd5467860
+  - image: icr.io/appcafe/open-liberty/samples/getting-started@sha256:b0d658e07e656a8cb3b02bf7194f788f4456c7ffe9d3361f96ac2807045dad80
     name: liberty-sample-app
   version: 1.2.1

--- a/bundle/manifests/open-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/open-liberty.clusterserviceversion.yaml
@@ -91,9 +91,9 @@ metadata:
     categories: Application Runtime
     certified: "true"
     containerImage: icr.io/appcafe/open-liberty-operator:daily
-    createdAt: "2023-05-01T09:38:53Z"
+    createdAt: "2023-06-16T14:45:48Z"
     description: Deploy and manage containerized Liberty applications
-    olm.skipRange: '>=0.8.0 <1.2.0'
+    olm.skipRange: '>=0.8.0 <1.2.1'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.24.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -104,7 +104,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: open-liberty.v1.2.0
+  name: open-liberty.v1.2.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1363,4 +1363,4 @@ spec:
   relatedImages:
   - image: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e22dd56a05e44618a10d275d3ff07a38eb364c0f04f86ffe9618d83dd5467860
     name: liberty-sample-app
-  version: 1.2.0
+  version: 1.2.1

--- a/bundle/tests/scorecard/kuttl/basic/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/basic/00-assert.yaml
@@ -13,4 +13,4 @@ metadata:
   name: example-liberty-app
 status:
   versions:
-    reconciled: 1.2.0
+    reconciled: 1.2.1

--- a/bundle/tests/scorecard/kuttl/dump/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/dump/01-assert.yaml
@@ -13,4 +13,4 @@ status:
       - status: "True"
         type: Completed
   versions:
-    reconciled: 1.2.0
+    reconciled: 1.2.1

--- a/bundle/tests/scorecard/kuttl/trace/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/trace/01-assert.yaml
@@ -17,4 +17,4 @@ status:
     resourceName: trace-liberty-0
     resourceType: pod
   versions:
-    reconciled: 1.2.0
+    reconciled: 1.2.1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -68,7 +68,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.annotations['olm.targetNamespaces']
           - name: RELATED_IMAGE_LIBERTY_SAMPLE_APP
-            value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e22dd56a05e44618a10d275d3ff07a38eb364c0f04f86ffe9618d83dd5467860
+            value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:b0d658e07e656a8cb3b02bf7194f788f4456c7ffe9d3361f96ac2807045dad80
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false

--- a/config/manifests/bases/open-liberty.clusterserviceversion.yaml
+++ b/config/manifests/bases/open-liberty.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     certified: "true"
     createdAt: "2022-03-01T09:00:00Z"
     description: Deploy and manage containerized Liberty applications
-    olm.skipRange: '>=0.8.0 <1.2.0'
+    olm.skipRange: '>=0.8.0 <1.2.1'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     repository: https://github.com/OpenLiberty/open-liberty-operator
     support: IBM

--- a/config/samples/apps.openliberty.io_v1_openlibertyapplications.yaml
+++ b/config/samples/apps.openliberty.io_v1_openlibertyapplications.yaml
@@ -3,7 +3,7 @@ kind: OpenLibertyApplication
 metadata:
   name: openliberty-app-sample
 spec:
-  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e22dd56a05e44618a10d275d3ff07a38eb364c0f04f86ffe9618d83dd5467860
+  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started@sha256:b0d658e07e656a8cb3b02bf7194f788f4456c7ffe9d3361f96ac2807045dad80
   expose: true
   manageTLS: true
   replicas: 1

--- a/config/samples/apps.openliberty.io_v1beta2_openlibertyapplications.yaml
+++ b/config/samples/apps.openliberty.io_v1beta2_openlibertyapplications.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openliberty-app-sample
 spec:
   # Add fields here
-  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e22dd56a05e44618a10d275d3ff07a38eb364c0f04f86ffe9618d83dd5467860
+  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started@sha256:b0d658e07e656a8cb3b02bf7194f788f4456c7ffe9d3361f96ac2807045dad80
   expose: true
   replicas: 1
   service:

--- a/ebcDockerBuilderOLO.jenkinsfile
+++ b/ebcDockerBuilderOLO.jenkinsfile
@@ -9,7 +9,7 @@ properties([
       string(name: 'command', defaultValue: "make build-operator-pipeline REGISTRY=cp.stg.icr.io", description: 'Build command to execute on target arch machine, e.g. make build-pipeline-releases'),
       string(name: 'PIPELINE_OPERATOR_IMAGE', defaultValue: "cp/olo-operator", description: 'namespace to push image to in registry'),
       string(name: 'RELEASE_TARGET', defaultValue: "main", description: 'release branch to use'),
-      string(name: 'OPM_VERSION', defaultValue: "4.10", description: 'Redhat CLI OPM version'),
+      string(name: 'OPM_VERSION', defaultValue: "4.12", description: 'Redhat CLI OPM version'),
       string(name: 'PIPELINE_PRODUCTION_IMAGE', defaultValue: "icr.io/cpopen/olo-operator", description: 'namespace in prod registry'),
       string(name: 'REDHAT_BASE_IMAGE', defaultValue: "registry.redhat.io/openshift4/ose-operator-registry", description: 'base image for operator'),
       string(name: 'REDHAT_REGISTRY', defaultValue: "registry.redhat.io", description: 'RH registry used for docker login'),

--- a/index.Dockerfile
+++ b/index.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/openshift4/ose-operator-registry:v4.10 AS builder
+FROM registry.redhat.io/openshift4/ose-operator-registry:v4.12 AS builder
 
 FROM registry.redhat.io/ubi8/ubi-minimal
 

--- a/index.Dockerfile
+++ b/index.Dockerfile
@@ -2,7 +2,7 @@ FROM registry.redhat.io/openshift4/ose-operator-registry:v4.10 AS builder
 
 FROM registry.redhat.io/ubi8/ubi-minimal
 
-ARG VERSION_LABEL=1.2.0
+ARG VERSION_LABEL=1.2.1
 ARG RELEASE_LABEL=XX
 ARG VCS_REF=0123456789012345678901234567890123456789
 ARG VCS_URL="https://github.com/OpenLiberty/open-liberty-operator"

--- a/internal/deploy/kubectl/openliberty-app-operator.yaml
+++ b/internal/deploy/kubectl/openliberty-app-operator.yaml
@@ -300,7 +300,7 @@ spec:
         - name: WATCH_NAMESPACE
           value: OPEN_LIBERTY_WATCH_NAMESPACE
         - name: RELATED_IMAGE_LIBERTY_SAMPLE_APP
-          value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e22dd56a05e44618a10d275d3ff07a38eb364c0f04f86ffe9618d83dd5467860
+          value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:b0d658e07e656a8cb3b02bf7194f788f4456c7ffe9d3361f96ac2807045dad80
         image: icr.io/appcafe/open-liberty-operator:daily
         livenessProbe:
           failureThreshold: 3

--- a/internal/deploy/kustomize/daily/base/open-liberty-operator.yaml
+++ b/internal/deploy/kustomize/daily/base/open-liberty-operator.yaml
@@ -50,7 +50,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: RELATED_IMAGE_LIBERTY_SAMPLE_APP
-          value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e22dd56a05e44618a10d275d3ff07a38eb364c0f04f86ffe9618d83dd5467860
+          value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:b0d658e07e656a8cb3b02bf7194f788f4456c7ffe9d3361f96ac2807045dad80
         image: icr.io/appcafe/open-liberty-operator:daily
         livenessProbe:
           failureThreshold: 3

--- a/scripts/installers/install-opm.sh
+++ b/scripts/installers/install-opm.sh
@@ -9,7 +9,7 @@ main() {
     exit 0
   fi
 
-  readonly DEFAULT_RELEASE_VERSION=latest-4.10
+  readonly DEFAULT_RELEASE_VERSION=latest-4.12
   readonly RELEASE_VERSION=${1:-$DEFAULT_RELEASE_VERSION}
   readonly base_url="https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${RELEASE_VERSION}"
 

--- a/scripts/update-sample.sh
+++ b/scripts/update-sample.sh
@@ -19,6 +19,7 @@ fi
 echo "sha is $SHA"
 
 files=" 
+config/samples/apps.openliberty.io_v1_openlibertyapplications.yaml
 config/samples/apps.openliberty.io_v1beta2_openlibertyapplications.yaml
 config/manager/manager.yaml
 internal/deploy/kustomize/daily/base/open-liberty-operator.yaml

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -32,7 +32,7 @@ var log = logf.Log.WithName("openliberty_utils")
 // Constant Values
 const serviceabilityMountPath = "/serviceability"
 const ssoEnvVarPrefix = "SEC_SSO_"
-const OperandVersion = "1.2.0"
+const OperandVersion = "1.2.1"
 
 // Validate if the OpenLibertyApplication is valid
 func Validate(olapp *olv1.OpenLibertyApplication) (bool, error) {


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Update the OLO version to 1.2.1
- Update the catalog base image (to resolve CVEs) and OPM version to 4.12. OCP 4.10 is supported till September 2023, so left the OC CLI version at 4.10 for now.
- Update sample app

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
