### PR TITLE
Added auto generation for kustomize artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,9 @@ bundle: manifests setup kustomize ## Generate bundle manifests and metadata, the
 	$(KUSTOMIZE) build config/kubectl/rbac-watch-all -o internal/deploy/kubectl/openliberty-app-rbac-watch-all.yaml
 	$(KUSTOMIZE) build config/kubectl/rbac-watch-another -o internal/deploy/kubectl/openliberty-app-rbac-watch-another.yaml
 
+	$(KUSTOMIZE) build config/kustomize/watch-all -o internal/deploy/kustomize/daily/overlays/watch-all-namespaces/cluster-roles.yaml
+	$(KUSTOMIZE) build config/kustomize/watch-another -o internal/deploy/kustomize/daily/overlays/watch-another-namespace/olo-watched-ns/watched-roles.yaml
+
 	operator-sdk bundle validate ./bundle
 
 .PHONY: fmt

--- a/config/kustomize/watch-all/kustomization.yaml
+++ b/config/kustomize/watch-all/kustomization.yaml
@@ -1,0 +1,93 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../rbac
+
+# Labels to add to all resources and selectors.
+commonLabels:
+  app.kubernetes.io/instance: open-liberty-operator
+  app.kubernetes.io/name: open-liberty-operator
+
+patches:
+- path: patches/delete-service-account.yaml
+  target:
+    kind: ServiceAccount
+
+patchesJson6902:
+  - target:
+      namespace: open-liberty-operator
+      name: .*
+    patch: |-
+      - op: remove
+        path: /metadata/namespace
+  - target:
+      kind: Role
+      name: .*
+    patch: |-
+      - op: replace
+        path: /kind
+        value: ClusterRole
+  - target:
+      kind: RoleBinding
+      name: .*
+    patch: |-
+      - op: replace
+        path: /kind
+        value: ClusterRoleBinding
+  - target:
+      kind: ClusterRoleBinding
+      name: .*
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: olo-controller-manager
+      - op: replace
+        path: /subjects/0/namespace
+        value: OPEN_LIBERTY_OPERATOR_NAMESPACE
+      - op: replace
+        path: /roleRef/kind
+        value: ClusterRole
+  - target:
+      kind: ClusterRoleBinding
+      name: leader-election-rolebinding
+    patch: |-
+      - op: replace
+        path: /roleRef/name
+        value: olo-leader-election-cluster-role
+      - op: replace
+        path: /metadata/name
+        value: olo-leader-election-cluster-rolebinding
+  - target:
+      kind: ClusterRoleBinding
+      name: manager-rolebinding
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: olo-manager-cluster-rolebinding
+      - op: replace
+        path: /roleRef/name
+        value: olo-manager-cluster-role
+  - target:
+      kind: ClusterRole
+      name: manager-role
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: olo-manager-cluster-role
+      - op: add
+        path: /rules/-
+        value: {"apiGroups":[""],"resources":["namespaces"],"verbs":["get","list","watch"]}
+  - target:
+      kind: ClusterRoleBinding
+      name: .*
+    patch: |-
+      - op: replace
+        path: /subjects/0/namespace
+        value: open-liberty
+  - target:
+      kind: ClusterRole
+      name: leader-election-role
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: olo-leader-election-cluster-role

--- a/config/kustomize/watch-all/patches/delete-service-account.yaml
+++ b/config/kustomize/watch-all/patches/delete-service-account.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: wlo-controller-manager

--- a/config/kustomize/watch-another/kustomization.yaml
+++ b/config/kustomize/watch-another/kustomization.yaml
@@ -1,0 +1,62 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../rbac
+
+namespace: olo-watched-ns
+
+# Labels to add to all resources and selectors.
+commonLabels:
+  app.kubernetes.io/instance: open-liberty-operator
+  app.kubernetes.io/name: open-liberty-operator
+
+patches:
+- path: patches/delete-service-account.yaml
+  target:
+    kind: ServiceAccount
+
+patchesJson6902:
+  - target:
+      kind: RoleBinding
+      name: manager-rolebinding
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: olo-watched-rolebinding
+      - op: replace
+        path: /roleRef/name
+        value: olo-watched-role
+  - target:
+      kind: RoleBinding
+      name: leader-election-rolebinding
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: olo-leader-election-watched-rolebinding
+      - op: replace
+        path: /roleRef/name
+        value: olo-leader-election-watched-role
+  - target:
+      kind: RoleBinding
+      name: .*
+    patch: |-
+      - op: replace
+        path: /subjects/0/namespace
+        value: olo-ns
+      - op: replace
+        path: /subjects/0/name
+        value: olo-controller-manager
+  - target:
+      kind: Role
+      name: leader-election-role
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: olo-leader-election-watched-role
+  - target:
+      kind: Role
+      name: manager-role
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: olo-watched-role

--- a/config/kustomize/watch-another/patches/delete-service-account.yaml
+++ b/config/kustomize/watch-another/patches/delete-service-account.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: wlo-controller-manager

--- a/internal/deploy/kustomize/daily/base/open-liberty-operator.yaml
+++ b/internal/deploy/kustomize/daily/base/open-liberty-operator.yaml
@@ -51,7 +51,7 @@ spec:
               fieldPath: metadata.namespace
         - name: RELATED_IMAGE_LIBERTY_SAMPLE_APP
           value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:d3c67c4a15c97b0fb82f9ef4a2ccf474232b878787e9eea39af75a3ac78469e3
-        image: icr.io/appcafe/open-liberty-operator:daily
+        image: icr.io/appcafe/open-liberty-operator:1.2.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/internal/deploy/kustomize/daily/overlays/watch-all-namespaces/cluster-roles.yaml
+++ b/internal/deploy/kustomize/daily/overlays/watch-all-namespaces/cluster-roles.yaml
@@ -1,34 +1,32 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: open-liberty-operator
     app.kubernetes.io/name: open-liberty-operator
-  name: olo-manager-cluster-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: olo-manager-cluster-role
-subjects:
-- kind: ServiceAccount
-  name: olo-controller-manager
-  namespace: open-liberty
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/instance: open-liberty-operator
-    app.kubernetes.io/name: open-liberty-operator
-  name: olo-leader-election-cluster-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
   name: olo-leader-election-cluster-role
-subjects:
-- kind: ServiceAccount
-  name: olo-controller-manager
-  namespace: open-liberty
+rules:
+- apiGroups:
+  - ""
+  - coordination.k8s.io
+  resources:
+  - configmaps
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -58,6 +56,48 @@ rules:
   - statefulsets
   verbs:
   - update
+- apiGroups:
+  - apps.openliberty.io
+  resources:
+  - openlibertyapplications
+  - openlibertyapplications/finalizers
+  - openlibertyapplications/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.openliberty.io
+  resources:
+  - openlibertydumps
+  - openlibertydumps/finalizers
+  - openlibertydumps/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.openliberty.io
+  resources:
+  - openlibertytraces
+  - openlibertytraces/finalizers
+  - openlibertytraces/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - autoscaling
   resources:
@@ -110,13 +150,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - list
-  - watch
-- apiGroups:
   - image.openshift.io
   resources:
   - imagestreams
@@ -124,48 +157,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
-- apiGroups:
-  - apps.openliberty.io
-  resources:
-  - openlibertyapplications
-  - openlibertyapplications/finalizers
-  - openlibertyapplications/status
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps.openliberty.io
-  resources:
-  - openlibertydumps
-  - openlibertydumps/finalizers
-  - openlibertydumps/status
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps.openliberty.io
-  resources:
-  - openlibertytraces
-  - openlibertytraces/finalizers
-  - openlibertytraces/status
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - monitoring.coreos.com
@@ -221,33 +212,43 @@ rules:
   - list
   - update
   - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app.kubernetes.io/instance: open-liberty-operator
-    app.kubernetes.io/name: open-liberty-operator
-  name: olo-leader-election-cluster-role
-rules:
 - apiGroups:
   - ""
-  - coordination.k8s.io
   resources:
-  - configmaps
-  - leases
+  - namespaces
   verbs:
   - get
   - list
   - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: open-liberty-operator
+    app.kubernetes.io/name: open-liberty-operator
+  name: olo-leader-election-cluster-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: olo-leader-election-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: olo-controller-manager
+  namespace: open-liberty
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: open-liberty-operator
+    app.kubernetes.io/name: open-liberty-operator
+  name: olo-manager-cluster-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: olo-manager-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: olo-controller-manager
+  namespace: open-liberty

--- a/internal/deploy/kustomize/daily/overlays/watch-another-namespace/olo-watched-ns/watched-roles.yaml
+++ b/internal/deploy/kustomize/daily/overlays/watch-another-namespace/olo-watched-ns/watched-roles.yaml
@@ -1,6 +1,37 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  labels:
+    app.kubernetes.io/instance: open-liberty-operator
+    app.kubernetes.io/name: open-liberty-operator
+  name: olo-leader-election-watched-role
+  namespace: olo-watched-ns
+rules:
+- apiGroups:
+  - ""
+  - coordination.k8s.io
+  resources:
+  - configmaps
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: open-liberty-operator
@@ -27,6 +58,48 @@ rules:
   - statefulsets
   verbs:
   - update
+- apiGroups:
+  - apps.openliberty.io
+  resources:
+  - openlibertyapplications
+  - openlibertyapplications/finalizers
+  - openlibertyapplications/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.openliberty.io
+  resources:
+  - openlibertydumps
+  - openlibertydumps/finalizers
+  - openlibertydumps/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.openliberty.io
+  resources:
+  - openlibertytraces
+  - openlibertytraces/finalizers
+  - openlibertytraces/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - autoscaling
   resources:
@@ -88,48 +161,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - apps.openliberty.io
-  resources:
-  - openlibertyapplications
-  - openlibertyapplications/finalizers
-  - openlibertyapplications/status
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps.openliberty.io
-  resources:
-  - openlibertydumps
-  - openlibertydumps/finalizers
-  - openlibertydumps/status
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps.openliberty.io
-  resources:
-  - openlibertytraces
-  - openlibertytraces/finalizers
-  - openlibertytraces/status
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors
@@ -185,35 +216,21 @@ rules:
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: open-liberty-operator
     app.kubernetes.io/name: open-liberty-operator
-  name: olo-leader-election-watched-role
+  name: olo-leader-election-watched-rolebinding
   namespace: olo-watched-ns
-rules:
-  - apiGroups:
-      - ""
-      - coordination.k8s.io
-    resources:
-      - configmaps
-      - leases
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - create
-      - patch
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: olo-leader-election-watched-role
+subjects:
+- kind: ServiceAccount
+  name: olo-controller-manager
+  namespace: olo-ns
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -231,21 +248,3 @@ subjects:
 - kind: ServiceAccount
   name: olo-controller-manager
   namespace: olo-ns
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/instance: open-liberty-operator
-    app.kubernetes.io/name: open-liberty-operator
-  name: olo-leader-election-watched-rolebinding
-  namespace: olo-watched-ns
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: olo-leader-election-watched-role
-subjects:
-- kind: ServiceAccount
-  name: olo-controller-manager
-  namespace: olo-ns
----


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Adds in auto generation for kustomize artifacts
- Updates the current artifacts with the output from the generator

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Related [websphere-liberty-operator/issues/446](https://github.com/WASdev/websphere-liberty-operator/issues/446)
