### PR TITLE
Patch probe defaults with port and scheme based on manageTLS

### DIFF
--- a/api/v1/openlibertyapplication_types.go
+++ b/api/v1/openlibertyapplication_types.go
@@ -142,15 +142,15 @@ type OpenLibertyApplicationSpec struct {
 type OpenLibertyApplicationProbes struct {
 	// Periodic probe of container liveness. Container will be restarted if the probe fails.
 	// +operator-sdk:csv:customresourcedefinitions:order=49,type=spec,displayName="Liveness Probe"
-	Liveness *corev1.Probe `json:"liveness,omitempty"`
+	Liveness *common.BaseComponentProbe `json:"liveness,omitempty"`
 
 	// Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails.
 	// +operator-sdk:csv:customresourcedefinitions:order=50,type=spec,displayName="Readiness Probe"
-	Readiness *corev1.Probe `json:"readiness,omitempty"`
+	Readiness *common.BaseComponentProbe `json:"readiness,omitempty"`
 
 	// Probe to determine successful initialization. If specified, other probes are not executed until this completes successfully.
 	// +operator-sdk:csv:customresourcedefinitions:order=51,type=spec,displayName="Startup Probe"
-	Startup *corev1.Probe `json:"startup,omitempty"`
+	Startup *common.BaseComponentProbe `json:"startup,omitempty"`
 }
 
 // Configure pods to run on particular Nodes.
@@ -640,32 +640,63 @@ func (cr *OpenLibertyApplication) GetProbes() common.BaseComponentProbes {
 }
 
 // GetLivenessProbe returns liveness probe
-func (p *OpenLibertyApplicationProbes) GetLivenessProbe() *corev1.Probe {
+func (p *OpenLibertyApplicationProbes) GetLivenessProbe() *common.BaseComponentProbe {
 	return p.Liveness
 }
 
 // GetReadinessProbe returns readiness probe
-func (p *OpenLibertyApplicationProbes) GetReadinessProbe() *corev1.Probe {
+func (p *OpenLibertyApplicationProbes) GetReadinessProbe() *common.BaseComponentProbe {
 	return p.Readiness
 }
 
 // GetStartupProbe returns startup probe
-func (p *OpenLibertyApplicationProbes) GetStartupProbe() *corev1.Probe {
+func (p *OpenLibertyApplicationProbes) GetStartupProbe() *common.BaseComponentProbe {
 	return p.Startup
 }
 
+func (p *OpenLibertyApplicationProbes) PatchLivenessProbe(ba common.BaseComponent, probe *common.BaseComponentProbe) *common.BaseComponentProbe {
+	return patchLibertyProbe(ba, probe)
+}
+
+func (p *OpenLibertyApplicationProbes) PatchReadinessProbe(ba common.BaseComponent, probe *common.BaseComponentProbe) *common.BaseComponentProbe {
+	return patchLibertyProbe(ba, probe)
+}
+
+func (p *OpenLibertyApplicationProbes) PatchStartupProbe(ba common.BaseComponent, probe *common.BaseComponentProbe) *common.BaseComponentProbe {
+	return patchLibertyProbe(ba, probe)
+}
+
+func patchLibertyProbe(ba common.BaseComponent, probe *common.BaseComponentProbe) *common.BaseComponentProbe {
+	if probe != nil {
+		manageTLSEnabled := ba.GetManageTLS() == nil || *ba.GetManageTLS()
+		if probe.BaseComponentProbeHandler.HTTPGet != nil {
+			if manageTLSEnabled {
+				probe.BaseComponentProbeHandler.HTTPGet.Scheme = "HTTPS"
+			} else {
+				probe.BaseComponentProbeHandler.HTTPGet.Scheme = "HTTP"
+			}
+			portValue := ba.GetService().GetPort()
+			if portValue != 0 {
+				port := intstr.FromInt(int(portValue))
+				probe.BaseComponentProbeHandler.HTTPGet.Port = &port
+			}
+		}
+	}
+	return probe
+}
+
 // GetDefaultLivenessProbe returns default values for liveness probe
-func (p *OpenLibertyApplicationProbes) GetDefaultLivenessProbe(ba common.BaseComponent) *corev1.Probe {
+func (p *OpenLibertyApplicationProbes) GetDefaultLivenessProbe(ba common.BaseComponent) *common.BaseComponentProbe {
 	return common.GetDefaultMicroProfileLivenessProbe(ba)
 }
 
 // GetDefaultReadinessProbe returns default values for readiness probe
-func (p *OpenLibertyApplicationProbes) GetDefaultReadinessProbe(ba common.BaseComponent) *corev1.Probe {
+func (p *OpenLibertyApplicationProbes) GetDefaultReadinessProbe(ba common.BaseComponent) *common.BaseComponentProbe {
 	return common.GetDefaultMicroProfileReadinessProbe(ba)
 }
 
 // GetDefaultStartupProbe returns default values for startup probe
-func (p *OpenLibertyApplicationProbes) GetDefaultStartupProbe(ba common.BaseComponent) *corev1.Probe {
+func (p *OpenLibertyApplicationProbes) GetDefaultStartupProbe(ba common.BaseComponent) *common.BaseComponentProbe {
 	return common.GetDefaultMicroProfileStartupProbe(ba)
 }
 

--- a/api/v1/openlibertydump_types.go
+++ b/api/v1/openlibertydump_types.go
@@ -41,6 +41,7 @@ type OpenLibertyDumpStatus struct {
 type DumpStatusVersions struct {
 	Reconciled string `json:"reconciled,omitempty"`
 }
+
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion

--- a/api/v1/openlibertytrace_types.go
+++ b/api/v1/openlibertytrace_types.go
@@ -36,6 +36,7 @@ type OpenLibertyTraceStatus struct {
 type TraceStatusVersions struct {
 	Reconciled string `json:"reconciled,omitempty"`
 }
+
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -361,17 +361,17 @@ func (in *OpenLibertyApplicationProbes) DeepCopyInto(out *OpenLibertyApplication
 	*out = *in
 	if in.Liveness != nil {
 		in, out := &in.Liveness, &out.Liveness
-		*out = new(corev1.Probe)
+		*out = new(common.BaseComponentProbe)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.Readiness != nil {
 		in, out := &in.Readiness, &out.Readiness
-		*out = new(corev1.Probe)
+		*out = new(common.BaseComponentProbe)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.Startup != nil {
 		in, out := &in.Startup, &out.Startup
-		*out = new(corev1.Probe)
+		*out = new(common.BaseComponentProbe)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/api/v1beta2/openlibertyapplication_types.go
+++ b/api/v1beta2/openlibertyapplication_types.go
@@ -126,26 +126,38 @@ type OpenLibertyApplicationSpec struct {
 type OpenLibertyApplicationProbes struct {
 	// Periodic probe of container liveness. Container will be restarted if the probe fails.
 	// +operator-sdk:csv:customresourcedefinitions:order=49,type=spec,displayName="Liveness Probe"
-	Liveness *corev1.Probe `json:"liveness,omitempty"`
+	Liveness *common.BaseComponentProbe `json:"liveness,omitempty"`
 
 	// Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails.
 	// +operator-sdk:csv:customresourcedefinitions:order=50,type=spec,displayName="Readiness Probe"
-	Readiness *corev1.Probe `json:"readiness,omitempty"`
+	Readiness *common.BaseComponentProbe `json:"readiness,omitempty"`
 
 	// Probe to determine successful initialization. If specified, other probes are not executed until this completes successfully.
 	// +operator-sdk:csv:customresourcedefinitions:order=51,type=spec,displayName="Startup Probe"
-	Startup *corev1.Probe `json:"startup,omitempty"`
+	Startup *common.BaseComponentProbe `json:"startup,omitempty"`
 }
 
-func (p *OpenLibertyApplicationProbes) GetDefaultLivenessProbe(common.BaseComponent) *corev1.Probe {
+func (p *OpenLibertyApplicationProbes) PatchLivenessProbe(ba common.BaseComponent, probe *common.BaseComponentProbe) *common.BaseComponentProbe {
+	return probe
+}
+
+func (p *OpenLibertyApplicationProbes) PatchReadinessProbe(ba common.BaseComponent, probe *common.BaseComponentProbe) *common.BaseComponentProbe {
+	return probe
+}
+
+func (p *OpenLibertyApplicationProbes) PatchStartupProbe(ba common.BaseComponent, probe *common.BaseComponentProbe) *common.BaseComponentProbe {
+	return probe
+}
+
+func (p *OpenLibertyApplicationProbes) GetDefaultLivenessProbe(common.BaseComponent) *common.BaseComponentProbe {
 	return nil
 }
 
-func (p *OpenLibertyApplicationProbes) GetDefaultReadinessProbe(common.BaseComponent) *corev1.Probe {
+func (p *OpenLibertyApplicationProbes) GetDefaultReadinessProbe(common.BaseComponent) *common.BaseComponentProbe {
 	return nil
 }
 
-func (p *OpenLibertyApplicationProbes) GetDefaultStartupProbe(common.BaseComponent) *corev1.Probe {
+func (p *OpenLibertyApplicationProbes) GetDefaultStartupProbe(common.BaseComponent) *common.BaseComponentProbe {
 	return nil
 }
 
@@ -538,17 +550,17 @@ func (cr *OpenLibertyApplication) GetProbes() common.BaseComponentProbes {
 }
 
 // GetLivenessProbe returns liveness probe
-func (p *OpenLibertyApplicationProbes) GetLivenessProbe() *corev1.Probe {
+func (p *OpenLibertyApplicationProbes) GetLivenessProbe() *common.BaseComponentProbe {
 	return p.Liveness
 }
 
 // GetReadinessProbe returns readiness probe
-func (p *OpenLibertyApplicationProbes) GetReadinessProbe() *corev1.Probe {
+func (p *OpenLibertyApplicationProbes) GetReadinessProbe() *common.BaseComponentProbe {
 	return p.Readiness
 }
 
 // GetStartupProbe returns startup probe
-func (p *OpenLibertyApplicationProbes) GetStartupProbe() *corev1.Probe {
+func (p *OpenLibertyApplicationProbes) GetStartupProbe() *common.BaseComponentProbe {
 	return p.Startup
 }
 

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v1beta2
 
 import (
+	"github.com/application-stacks/runtime-component-operator/common"
 	routev1 "github.com/openshift/api/route/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -281,17 +282,17 @@ func (in *OpenLibertyApplicationProbes) DeepCopyInto(out *OpenLibertyApplication
 	*out = *in
 	if in.Liveness != nil {
 		in, out := &in.Liveness, &out.Liveness
-		*out = new(v1.Probe)
+		*out = new(common.BaseComponentProbe)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.Readiness != nil {
 		in, out := &in.Readiness, &out.Readiness
-		*out = new(v1.Probe)
+		*out = new(common.BaseComponentProbe)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.Startup != nil {
 		in, out := &in.Startup, &out.Startup
-		*out = new(v1.Probe)
+		*out = new(common.BaseComponentProbe)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/config/crd/bases/apps.openliberty.io_openlibertyapplications.yaml
+++ b/config/crd/bases/apps.openliberty.io_openlibertyapplications.yaml
@@ -2990,7 +2990,7 @@ spec:
                       failureThreshold:
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
-                          3. Minimum value is 1.
+                          nil.
                         format: int32
                         type: integer
                       grpc:
@@ -3053,8 +3053,6 @@ spec:
                             description: Scheme to use for connecting to the host.
                               Defaults to HTTP.
                             type: string
-                        required:
-                        - port
                         type: object
                       initialDelaySeconds:
                         description: 'Number of seconds after the container has started
@@ -3063,14 +3061,13 @@ spec:
                         type: integer
                       periodSeconds:
                         description: How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
+                          Defaults to nil.
                         format: int32
                         type: integer
                       successThreshold:
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
+                          nil.
                         format: int32
                         type: integer
                       tcpSocket:
@@ -3105,14 +3102,12 @@ spec:
                           The value zero indicates stop immediately via the kill signal
                           (no opportunity to shut down). This is a beta field and
                           requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is
-                          used if unset.
+                          Defaults to nil
                         format: int64
                         type: integer
                       timeoutSeconds:
                         description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          out. Defaults to nil. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                         format: int32
                         type: integer
                     type: object
@@ -3139,7 +3134,7 @@ spec:
                       failureThreshold:
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
-                          3. Minimum value is 1.
+                          nil.
                         format: int32
                         type: integer
                       grpc:
@@ -3202,8 +3197,6 @@ spec:
                             description: Scheme to use for connecting to the host.
                               Defaults to HTTP.
                             type: string
-                        required:
-                        - port
                         type: object
                       initialDelaySeconds:
                         description: 'Number of seconds after the container has started
@@ -3212,14 +3205,13 @@ spec:
                         type: integer
                       periodSeconds:
                         description: How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
+                          Defaults to nil.
                         format: int32
                         type: integer
                       successThreshold:
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
+                          nil.
                         format: int32
                         type: integer
                       tcpSocket:
@@ -3254,14 +3246,12 @@ spec:
                           The value zero indicates stop immediately via the kill signal
                           (no opportunity to shut down). This is a beta field and
                           requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is
-                          used if unset.
+                          Defaults to nil
                         format: int64
                         type: integer
                       timeoutSeconds:
                         description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          out. Defaults to nil. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                         format: int32
                         type: integer
                     type: object
@@ -3289,7 +3279,7 @@ spec:
                       failureThreshold:
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
-                          3. Minimum value is 1.
+                          nil.
                         format: int32
                         type: integer
                       grpc:
@@ -3352,8 +3342,6 @@ spec:
                             description: Scheme to use for connecting to the host.
                               Defaults to HTTP.
                             type: string
-                        required:
-                        - port
                         type: object
                       initialDelaySeconds:
                         description: 'Number of seconds after the container has started
@@ -3362,14 +3350,13 @@ spec:
                         type: integer
                       periodSeconds:
                         description: How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
+                          Defaults to nil.
                         format: int32
                         type: integer
                       successThreshold:
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
+                          nil.
                         format: int32
                         type: integer
                       tcpSocket:
@@ -3404,14 +3391,12 @@ spec:
                           The value zero indicates stop immediately via the kill signal
                           (no opportunity to shut down). This is a beta field and
                           requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is
-                          used if unset.
+                          Defaults to nil
                         format: int64
                         type: integer
                       timeoutSeconds:
                         description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          out. Defaults to nil. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                         format: int32
                         type: integer
                     type: object
@@ -10148,7 +10133,7 @@ spec:
                       failureThreshold:
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
-                          3. Minimum value is 1.
+                          nil.
                         format: int32
                         type: integer
                       grpc:
@@ -10211,8 +10196,6 @@ spec:
                             description: Scheme to use for connecting to the host.
                               Defaults to HTTP.
                             type: string
-                        required:
-                        - port
                         type: object
                       initialDelaySeconds:
                         description: 'Number of seconds after the container has started
@@ -10221,14 +10204,13 @@ spec:
                         type: integer
                       periodSeconds:
                         description: How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
+                          Defaults to nil.
                         format: int32
                         type: integer
                       successThreshold:
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
+                          nil.
                         format: int32
                         type: integer
                       tcpSocket:
@@ -10263,14 +10245,12 @@ spec:
                           The value zero indicates stop immediately via the kill signal
                           (no opportunity to shut down). This is a beta field and
                           requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is
-                          used if unset.
+                          Defaults to nil
                         format: int64
                         type: integer
                       timeoutSeconds:
                         description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          out. Defaults to nil. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                         format: int32
                         type: integer
                     type: object
@@ -10297,7 +10277,7 @@ spec:
                       failureThreshold:
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
-                          3. Minimum value is 1.
+                          nil.
                         format: int32
                         type: integer
                       grpc:
@@ -10360,8 +10340,6 @@ spec:
                             description: Scheme to use for connecting to the host.
                               Defaults to HTTP.
                             type: string
-                        required:
-                        - port
                         type: object
                       initialDelaySeconds:
                         description: 'Number of seconds after the container has started
@@ -10370,14 +10348,13 @@ spec:
                         type: integer
                       periodSeconds:
                         description: How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
+                          Defaults to nil.
                         format: int32
                         type: integer
                       successThreshold:
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
+                          nil.
                         format: int32
                         type: integer
                       tcpSocket:
@@ -10412,14 +10389,12 @@ spec:
                           The value zero indicates stop immediately via the kill signal
                           (no opportunity to shut down). This is a beta field and
                           requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is
-                          used if unset.
+                          Defaults to nil
                         format: int64
                         type: integer
                       timeoutSeconds:
                         description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          out. Defaults to nil. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                         format: int32
                         type: integer
                     type: object
@@ -10447,7 +10422,7 @@ spec:
                       failureThreshold:
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
-                          3. Minimum value is 1.
+                          nil.
                         format: int32
                         type: integer
                       grpc:
@@ -10510,8 +10485,6 @@ spec:
                             description: Scheme to use for connecting to the host.
                               Defaults to HTTP.
                             type: string
-                        required:
-                        - port
                         type: object
                       initialDelaySeconds:
                         description: 'Number of seconds after the container has started
@@ -10520,14 +10493,13 @@ spec:
                         type: integer
                       periodSeconds:
                         description: How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
+                          Defaults to nil.
                         format: int32
                         type: integer
                       successThreshold:
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
+                          nil.
                         format: int32
                         type: integer
                       tcpSocket:
@@ -10562,14 +10534,12 @@ spec:
                           The value zero indicates stop immediately via the kill signal
                           (no opportunity to shut down). This is a beta field and
                           requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is
-                          used if unset.
+                          Defaults to nil
                         format: int64
                         type: integer
                       timeoutSeconds:
                         description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          out. Defaults to nil. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                         format: int32
                         type: integer
                     type: object


### PR DESCRIPTION
- Override the probe defaults with the `OpenLibertyApplication`'s Service `port` and update `scheme` to `HTTPS` if manageTLS is true (or if the flag is unset) otherwise set to `HTTP`.

Related issue https://github.com/OpenLiberty/open-liberty-operator/issues/442