### PR TITLE
RCO utils update to filter knative annotations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OpenLiberty/open-liberty-operator
 go 1.21
 
 require (
-	github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20231012214154-373cb504000d
+	github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20231024192226-922d2a5db383
 	github.com/cert-manager/cert-manager v1.10.2
 	github.com/go-logr/logr v1.2.4
 	github.com/openshift/api v0.0.0-20230928134114-673ed0cfc7f1

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20231012214154-373cb504000d h1:P8MnP9cxZ19PrMqqA60TeT2YXgDz+/kQer0rJJDEAEk=
 github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20231012214154-373cb504000d/go.mod h1:mQO6jtL9OMEzAx+IyCTDyEUm9wN1vUeunw0aROcepBw=
+github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20231024192226-922d2a5db383 h1:X0UjPYAsuK+ByO9Iy18ZxPjOPnFYUWE+yBX5tM5606M=
+github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20231024192226-922d2a5db383/go.mod h1:mQO6jtL9OMEzAx+IyCTDyEUm9wN1vUeunw0aROcepBw=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=


### PR DESCRIPTION
Pick up fix from RCO to filter out knative annotations from the knative service, as this causes a knative error

OLO fix for #474
