### PR TITLE
Update to latest RCO - pick up config map fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OpenLiberty/open-liberty-operator
 go 1.21
 
 require (
-	github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20231101204909-42a1eb2ab28b
+	github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20231110151527-b5d45ab23956
 	github.com/cert-manager/cert-manager v1.10.2
 	github.com/go-logr/logr v1.2.4
 	github.com/openshift/api v0.0.0-20230928134114-673ed0cfc7f1

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20231101204909-42a1eb2ab28b h1:Eb+7GZz2VcC83mnMgDEtCJe8cQF2fM58rrG+TwnGj3Y=
 github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20231101204909-42a1eb2ab28b/go.mod h1:Yhxg+reeWEw4OnPUsX3ZYogS3RbtmC0M20TzX/w4N0I=
+github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20231110151527-b5d45ab23956 h1:XpGY0dnfwe2dqe2clg6SnPQPTSFISpIb3yIqy196t+E=
+github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20231110151527-b5d45ab23956/go.mod h1:Yhxg+reeWEw4OnPUsX3ZYogS3RbtmC0M20TzX/w4N0I=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=


### PR DESCRIPTION
Pick up the fix to properly read the operator configmap when watching another namespace

OLO fix for https://github.com/application-stacks/runtime-component-operator/issues/590