### PR TITLE
Add RBAC perms for LTPA tests

### DIFF
--- a/config/rbac/kind-kuttl-rbac.yaml
+++ b/config/rbac/kind-kuttl-rbac.yaml
@@ -132,3 +132,12 @@ rules:
   - get
   - list
   - delete
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - patch
+  - delete

--- a/config/rbac/kuttl-rbac.yaml
+++ b/config/rbac/kuttl-rbac.yaml
@@ -135,4 +135,12 @@ rules:
   - get
   - list
   - delete
-
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - patch
+  - delete


### PR DESCRIPTION
Add RBAC perms for LTPA tests
- Kuttl needs ability to get, list, patch and delete the Job resource covering the `ltpa` and `ltpa-outdated-job` tests