### PR TITLE
Add a Failed condition to OpenLibertyDump

### DIFF
--- a/api/v1/openlibertydump_types.go
+++ b/api/v1/openlibertydump_types.go
@@ -31,6 +31,7 @@ const (
 // Defines the observed state of OpenLibertyDump
 type OpenLibertyDumpStatus struct {
 	// +listType=atomic
+	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Status Conditions",xDescriptors="urn:alm:descriptor:io.kubernetes.conditions"
 	Conditions []OperationStatusCondition `json:"conditions,omitempty"`
 	Versions   DumpStatusVersions         `json:"versions,omitempty"`
 	// Location of the generated dump file

--- a/api/v1/openlibertytrace_types.go
+++ b/api/v1/openlibertytrace_types.go
@@ -28,6 +28,7 @@ type OpenLibertyTraceSpec struct {
 // Defines the observed state of OpenLibertyTrace operation
 type OpenLibertyTraceStatus struct {
 	// +listType=atomic
+	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Status Conditions",xDescriptors="urn:alm:descriptor:io.kubernetes.conditions"
 	Conditions       []OperationStatusCondition `json:"conditions,omitempty"`
 	OperatedResource OperatedResource           `json:"operatedResource,omitempty"`
 	Versions         TraceStatusVersions        `json:"versions,omitempty"`

--- a/api/v1/operations.go
+++ b/api/v1/operations.go
@@ -51,6 +51,8 @@ const (
 	OperationStatusConditionTypeEnabled OperationStatusConditionType = "Enabled"
 	// OperationStatusConditionTypeStarted indicates whether operation has been started
 	OperationStatusConditionTypeStarted OperationStatusConditionType = "Started"
+	// OperationStatusConditionTypeFailed indicates whether operation has failed
+	OperationStatusConditionTypeFailed OperationStatusConditionType = "Failed"
 	// OperationStatusConditionTypeCompleted indicates whether operation has been completed
 	OperationStatusConditionTypeCompleted OperationStatusConditionType = "Completed"
 )

--- a/bundle/manifests/open-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/open-liberty.clusterserviceversion.yaml
@@ -28,8 +28,7 @@ metadata:
           },
           "spec": {
             "include": [
-              "thread",
-              "heap"
+              "thread"
             ],
             "podName": "Specify_Pod_Name_Here"
           }
@@ -70,8 +69,7 @@ metadata:
           },
           "spec": {
             "include": [
-              "thread",
-              "heap"
+              "thread"
             ],
             "podName": "Specify_Pod_Name_Here"
           }
@@ -94,7 +92,7 @@ metadata:
     categories: Application Runtime
     certified: "true"
     containerImage: icr.io/appcafe/open-liberty-operator:daily
-    createdAt: "2024-02-02T17:24:41Z"
+    createdAt: "2024-03-13T14:46:03Z"
     description: Deploy and manage containerized Liberty applications
     olm.skipRange: '>=0.8.0 <1.3.1'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
@@ -996,6 +994,10 @@ spec:
       kind: OpenLibertyDump
       name: openlibertydumps.apps.openliberty.io
       statusDescriptors:
+      - displayName: Status Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
       - description: Location of the generated dump file
         displayName: Dump File Path
         path: dumpFile
@@ -1011,6 +1013,11 @@ spec:
       displayName: OpenLibertyTrace
       kind: OpenLibertyTrace
       name: openlibertytraces.apps.openliberty.io
+      statusDescriptors:
+      - displayName: Status Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
       version: v1
     - description: Day-2 operation for gathering server traces
       displayName: OpenLibertyTrace

--- a/config/manifests/bases/open-liberty.clusterserviceversion.yaml
+++ b/config/manifests/bases/open-liberty.clusterserviceversion.yaml
@@ -830,6 +830,10 @@ spec:
       kind: OpenLibertyDump
       name: openlibertydumps.apps.openliberty.io
       statusDescriptors:
+      - displayName: Status Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
       - description: Location of the generated dump file
         displayName: Dump File Path
         path: dumpFile
@@ -845,6 +849,11 @@ spec:
       displayName: OpenLibertyTrace
       kind: OpenLibertyTrace
       name: openlibertytraces.apps.openliberty.io
+      statusDescriptors:
+      - displayName: Status Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
       version: v1
     - description: Day-2 operation for gathering server traces
       displayName: OpenLibertyTrace

--- a/controllers/openlibertydump_controller.go
+++ b/controllers/openlibertydump_controller.go
@@ -78,12 +78,18 @@ func (r *ReconcileOpenLibertyDump) Reconcile(ctx context.Context, request ctrl.R
 		reqLogger.Error(err, message)
 		r.Recorder.Event(instance, "Warning", "ProcessingError", message)
 		c := openlibertyv1.OperationStatusCondition{
-			Type:    openlibertyv1.OperationStatusConditionTypeStarted,
-			Status:  corev1.ConditionFalse,
+			Type:   openlibertyv1.OperationStatusConditionTypeStarted,
+			Status: corev1.ConditionFalse,
+		}
+		instance.Status.Conditions = openlibertyv1.SetOperationCondtion(instance.Status.Conditions, c)
+		// Additionally, set the condition to Failed to update the UI
+		f := openlibertyv1.OperationStatusCondition{
+			Type:    openlibertyv1.OperationStatusConditionTypeFailed,
+			Status:  corev1.ConditionTrue,
 			Reason:  "Error",
 			Message: "Failed to find a pod or pod is not in running state",
 		}
-		instance.Status.Conditions = openlibertyv1.SetOperationCondtion(instance.Status.Conditions, c)
+		instance.Status.Conditions = openlibertyv1.SetOperationCondtion(instance.Status.Conditions, f)
 		instance.Status.Versions.Reconciled = utils.OperandVersion
 		r.Client.Status().Update(context.TODO(), instance)
 		return reconcile.Result{}, nil
@@ -104,8 +110,12 @@ func (r *ReconcileOpenLibertyDump) Reconcile(ctx context.Context, request ctrl.R
 		Type:   openlibertyv1.OperationStatusConditionTypeStarted,
 		Status: corev1.ConditionTrue,
 	}
-
 	instance.Status.Conditions = openlibertyv1.SetOperationCondtion(instance.Status.Conditions, c)
+	f := openlibertyv1.OperationStatusCondition{
+		Type:   openlibertyv1.OperationStatusConditionTypeFailed,
+		Status: corev1.ConditionFalse,
+	}
+	instance.Status.Conditions = openlibertyv1.SetOperationCondtion(instance.Status.Conditions, f)
 	r.Client.Status().Update(context.TODO(), instance)
 
 	_, err = utils.ExecuteCommandInContainer(r.RestConfig, pod.Name, pod.Namespace, "app", []string{"/bin/sh", "-c", dumpCmd})
@@ -114,12 +124,18 @@ func (r *ReconcileOpenLibertyDump) Reconcile(ctx context.Context, request ctrl.R
 		reqLogger.Error(err, "Execute dump cmd failed ", "cmd", dumpCmd)
 		r.Recorder.Event(instance, "Warning", "ProcessingError", err.Error())
 		c = openlibertyv1.OperationStatusCondition{
-			Type:    openlibertyv1.OperationStatusConditionTypeCompleted,
-			Status:  corev1.ConditionFalse,
+			Type:   openlibertyv1.OperationStatusConditionTypeCompleted,
+			Status: corev1.ConditionFalse,
+		}
+		instance.Status.Conditions = openlibertyv1.SetOperationCondtion(instance.Status.Conditions, c)
+		// Additionally, set the condition to Failed to update the UI
+		f = openlibertyv1.OperationStatusCondition{
+			Type:    openlibertyv1.OperationStatusConditionTypeFailed,
+			Status:  corev1.ConditionTrue,
 			Reason:  "Error",
 			Message: err.Error(),
 		}
-		instance.Status.Conditions = openlibertyv1.SetOperationCondtion(instance.Status.Conditions, c)
+		instance.Status.Conditions = openlibertyv1.SetOperationCondtion(instance.Status.Conditions, f)
 		r.Client.Status().Update(context.TODO(), instance)
 		return reconcile.Result{}, nil
 
@@ -129,8 +145,12 @@ func (r *ReconcileOpenLibertyDump) Reconcile(ctx context.Context, request ctrl.R
 		Type:   openlibertyv1.OperationStatusConditionTypeCompleted,
 		Status: corev1.ConditionTrue,
 	}
-
 	instance.Status.Conditions = openlibertyv1.SetOperationCondtion(instance.Status.Conditions, c)
+	f = openlibertyv1.OperationStatusCondition{
+		Type:   openlibertyv1.OperationStatusConditionTypeFailed,
+		Status: corev1.ConditionFalse,
+	}
+	instance.Status.Conditions = openlibertyv1.SetOperationCondtion(instance.Status.Conditions, f)
 	instance.Status.DumpFile = dumpFileName
 	instance.Status.Versions.Reconciled = utils.OperandVersion
 	r.Client.Status().Update(context.TODO(), instance)


### PR DESCRIPTION
Related issue: https://github.com/OpenLiberty/open-liberty-operator/issues/538

Conditions are only displayed in the OpenShift UI when set to True.
This causes errors to not be displayed in the UI when `Completed = False` errors.
By creating a new condition `Failed = True` taking the error from above, it will properly update the UI to inform the WLO user that the OpenLibertyDump failed.