### PR TITLE
Update Observability guides for OCP 4.15

### DIFF
--- a/doc/observability-deployment.adoc
+++ b/doc/observability-deployment.adoc
@@ -1,6 +1,6 @@
 = Observability with Open Liberty
 
-The following document covers various topics for configuring and integrating your Open Liberty runtime with monitoring tools in a Kubernetes environment. This document has been tested and supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12 and 4.14.
+The following document covers various topics for configuring and integrating your Open Liberty runtime with monitoring tools in a Kubernetes environment. This document has been tested and supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12, 4.14, and 4.15.
 
 == How to analyze Open Liberty logs
 

--- a/doc/observability-deployment.adoc
+++ b/doc/observability-deployment.adoc
@@ -1,6 +1,6 @@
 = Observability with Open Liberty
 
-The following document covers various topics for configuring and integrating your Open Liberty runtime with monitoring tools in a Kubernetes environment. This document has been tested and supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12, 4.14, and 4.15.
+The following document covers various topics for configuring and integrating your Open Liberty runtime with monitoring tools in a Kubernetes environment. This document has been tested and is supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12, 4.14, and 4.15.
 
 == How to analyze Open Liberty logs
 

--- a/doc/openshift-logging-rhocp_4.7+.adoc
+++ b/doc/openshift-logging-rhocp_4.7+.adoc
@@ -1,6 +1,6 @@
 # Application Logging on Red Hat OpenShift Container Platform (RHOCP) with Elasticsearch, Fluentd, and Kibana 
 
-The following guide has been tested and supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12 and 4.14.
+The following guide has been tested and supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12, 4.14, and 4.15.
 
 Pod processes running in Kubernetes frequently produce logs. To effectively manage this log data and ensure no loss of log data occurs when a pod terminates, a log aggregation tool should be deployed on the Kubernetes cluster. Log aggregation tools help users persist, search, and visualize the log data that is gathered from the pods across the cluster. Log aggregation tools in the market today include:  EFK, LogDNA, Splunk, Datadog, IBM Operations Analytics, etc.  When considering log aggregation tools, enterprises make choices that are inclusive of their journey to cloud, both new cloud-native applications running in Kubernetes and their existing traditional IT choices.
 
@@ -8,7 +8,9 @@ One choice for application logging with log aggregation, based on open source, i
 
 ## Install Openshift Logging
 
-To install the Openshift Logging component, follow the OpenShift guide  link:++https://docs.openshift.com/container-platform/4.14/logging/cluster-logging-deploying.html++[Installing Openshift Logging]. Ensure you set up valid storage for Elasticsearch via Persistent Volumes. When the example Openshift Logging instance YAML from the guide is deployed, the Elasticsearch pods that are created automatically search for Persistent Volumes to bind to; if there are none available for binding, the Elasticsearch pods are stuck in a pending state. Using in-memory storage is also possible by removing the `storage` definition from the Openshift Logging instance YAML, but this is not suitable for production.
+To install the Openshift Logging component, follow the OpenShift guide  link:++https://docs.openshift.com/container-platform/4.15/logging/cluster-logging-deploying.html++[Installing Openshift Logging]. OpenShift now provides two log store options: the OpenShift Elasticsearch Operator (that is used in this guide) and the Loki Operator. Before deploying the example Cluster Logging instance YAML in the guide, install the OpenShift Elasticsearch Operator into all namespaces in your cluster.
+
+Ensure you set up valid storage for Elasticsearch via Persistent Volumes. When the example Cluster Logging instance YAML from the guide is deployed, the Elasticsearch pods that are created automatically search for Persistent Volumes to bind to; if there are none available for binding, the Elasticsearch pods are stuck in a pending state. Using in-memory storage is also possible by removing the `storage` definition from the Openshift Logging instance YAML, but this is not suitable for production.
 
 After the installation completes without any error, you can see the following pods that are running in the *openshift-logging* namespace. The exact number of pods running for each of the EFK components can vary depending on the configuration specified in the ClusterLogging Custom Resource (CR).
 
@@ -106,7 +108,7 @@ Deploy the Cluster Log Forwarder instance with the following command:
 oc create -f cluster-logging-forwarder.yaml
 ----
 
-For more information on parsing JSON logs in RHOCP, see the the OpenShift guide link:++https://docs.openshift.com/container-platform/4.14/logging/log_collection_forwarding/cluster-logging-enabling-json-logging.html++[Enabling JSON logging].
+For more information on parsing JSON logs in RHOCP, see the the OpenShift guide link:++https://docs.openshift.com/container-platform/4.15/logging/log_collection_forwarding/cluster-logging-enabling-json-logging.html++[Enabling JSON logging].
 
 ## View application logs in Kibana
 

--- a/doc/openshift-logging-rhocp_4.7+.adoc
+++ b/doc/openshift-logging-rhocp_4.7+.adoc
@@ -1,6 +1,6 @@
 # Application Logging on Red Hat OpenShift Container Platform (RHOCP) with Elasticsearch, Fluentd, and Kibana 
 
-The following guide has been tested and supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12, 4.14, and 4.15.
+The following guide has been tested and is supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12, 4.14, and 4.15.
 
 Pod processes running in Kubernetes frequently produce logs. To effectively manage this log data and ensure no loss of log data occurs when a pod terminates, a log aggregation tool should be deployed on the Kubernetes cluster. Log aggregation tools help users persist, search, and visualize the log data that is gathered from the pods across the cluster. Log aggregation tools in the market today include:  EFK, LogDNA, Splunk, Datadog, IBM Operations Analytics, etc.  When considering log aggregation tools, enterprises make choices that are inclusive of their journey to cloud, both new cloud-native applications running in Kubernetes and their existing traditional IT choices.
 

--- a/doc/openshift-monitoring.adoc
+++ b/doc/openshift-monitoring.adoc
@@ -1,6 +1,6 @@
 # Application Monitoring on Red Hat OpenShift Container Platform (RHOCP) with Prometheus and Grafana
 
-The following guide has been tested and supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12 and 4.14.
+The following guide has been tested and supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12, 4.14, and 4.15.
 
 ## Prerequisites
 
@@ -14,9 +14,9 @@ In RHOCP 4.6+, application monitoring can be set up by enabling monitoring for u
 
 There is no separate Grafana deployment that comes with enabling user-defined monitoring and the existing Grafana instance provided with the default monitoring stack is read-only, so a community-powered Grafana Operator must be installed later to create custom dashboards for viewing your metrics.
 
-. To configure the monitoring stack, follow this OpenShift guide link:++https://docs.openshift.com/container-platform/4.14/monitoring/configuring-the-monitoring-stack.html#preparing-to-configure-the-monitoring-stack++[Configuring the monitoring stack]. Here, you will create two config maps, `cluster-monitoring-config` and `user-workload-monitoring-config`, that will allow you to enable monitoring for user-defined projects in the next step. After creating the `user-workload-monitoring-config` config map, return to this guide to continue setting up monitoring for user-defined projects.
+. To configure the monitoring stack, follow this OpenShift guide link:++https://docs.openshift.com/container-platform/4.15/monitoring/configuring-the-monitoring-stack.html#preparing-to-configure-the-monitoring-stack++[Configuring the monitoring stack]. Here, you will create two config maps, `cluster-monitoring-config` and `user-workload-monitoring-config`, that will allow you to enable monitoring for user-defined projects in the next step. After creating the `user-workload-monitoring-config` config map, return to this guide to continue setting up monitoring for user-defined projects.
 
-. To enable monitoring for user-defined projects, follow the OpenShift guide link:++https://docs.openshift.com/container-platform/4.14/monitoring/enabling-monitoring-for-user-defined-projects.html++[Enabling monitoring for user-defined projects].
+. To enable monitoring for user-defined projects, follow the OpenShift guide link:++https://docs.openshift.com/container-platform/4.15/monitoring/enabling-monitoring-for-user-defined-projects.html++[Enabling monitoring for user-defined projects].
 
 . Deploy a Service Monitor inside the `myapp` namespace to define the service endpoint that will be monitored by the Prometheus instance. Add the following YAML to your OpenLibertyApplication Custom Resource (CR):
 
@@ -34,9 +34,41 @@ spec:
 
 . Under Observe > Metrics (formerly Monitoring > Metrics), confirm that your service is being monitored by inserting your own queries specific to your app's metrics.
 
-. To deploy an additional Grafana instance for creating custom dashboards, follow this RedHat blog link:++https://www.redhat.com/en/blog/custom-grafana-dashboards-red-hat-openshift-container-platform-4++[Custom Grafana dashboards for Red Hat OpenShift Container Platform 4]. This Grafana instance will be connected to OpenShift monitoring in the `openshift-monitoring` namespace and additional Grafana dashboards will increase the load on the Prometheus service, so pay attention to Prometheus' CPU and memory usage when deploying dashboards. Example Grafana instance YAML files can be found link:++https://grafana-operator.github.io/grafana-operator/docs/examples++[here].
+. To deploy an additional Grafana instance for creating custom dashboards, follow this RedHat blog link:++https://www.redhat.com/en/blog/custom-grafana-dashboards-red-hat-openshift-container-platform-4++[Custom Grafana dashboards for Red Hat OpenShift Container Platform 4]. This Grafana instance will be connected to OpenShift monitoring in the `openshift-monitoring` namespace and additional Grafana dashboards will increase the load on the Prometheus service, so pay attention to Prometheus' CPU and memory usage when deploying dashboards. Example Grafana instance YAML files can be found link:++https://grafana-operator.github.io/grafana-operator/docs/examples++[here]. Note: The Grafana Operator's `apiVersion` and Custom Resources have been renamed since the creation of the RedHat blog above. When you are deploying the Grafana Datasource in the blog, use the following YAML instead.
+
++
+[source,yaml]
+----
+kind: GrafanaDatasource
+apiVersion: grafana.integreatly.org/v1beta1
+metadata:
+  name: prometheus-grafanadatasource
+  namespace: my-grafana
+spec:
+  datasource:
+    access: proxy
+    editable: true
+    isDefault: true
+    jsonData:
+      httpHeaderName1: 'Authorization'
+      timeInterval: 5s
+      tlsSkipVerify: true
+    name: Prometheus
+    secureJsonData:
+      httpHeaderValue1: 'Bearer ${BEARER_TOKEN}'
+    type: prometheus
+    url: 'https://thanos-querier.openshift-monitoring.svc.cluster.local:9091'
+instanceSelector:
+    matchLabels:
+      dashboards: grafana-a
+  plugins:
+    - name: grafana-clock-panel
+      version: 1.3.0
+----
++
 
 . Deploy the following template Grafana Dashboard link:++https://github.com/OpenLiberty/open-liberty-operator/blob/main/doc/guides-code/grafana_dashboard.yaml.txt++[grafana_dashboard.yaml.txt] to see all the services currently being monitored. Please ensure that the namespace in this yaml is configured to the namespace already deployed.
+
 
 . Under Networking > Routes, visit Grafana to see the template dashboard. You can now consume all the application metrics gathered by Prometheus on the Grafana dashboard.
 

--- a/doc/openshift-monitoring.adoc
+++ b/doc/openshift-monitoring.adoc
@@ -1,6 +1,6 @@
 # Application Monitoring on Red Hat OpenShift Container Platform (RHOCP) with Prometheus and Grafana
 
-The following guide has been tested and supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12, 4.14, and 4.15.
+The following guide has been tested and is supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12, 4.14, and 4.15.
 
 ## Prerequisites
 


### PR DESCRIPTION
**Description of changes:**

Logging Guide:

The OCP guides removed mention of installing the OpenShift Elasticsearch Operator, since they now provide two log store options: the OpenShift Elasticsearch Operator and the Loki Operator (so it's up to the user to choose). However, the cluster logging instance deployed later uses Elasticsearch as its log store, so for simplicity, I just added an instruction to install the Elasticsearch Operator as well.

To consider: The guide also says that the Elasticsearch Operator is now deprecated, and that we should look to using Loki/Vector as the future option instead.

Monitoring Guide:

The Grafana Operator's CRs and apiVersion have been renamed, so a direct copy paste of the yaml from the blog won't work for deploying the Grafana datasource CR. I've added a replacement yaml with the proper naming.

Observability Guide:

Just version support additions.
