### PR TITLE
Support password encryption key sharing

### DIFF
--- a/api/v1/openlibertyapplication_types.go
+++ b/api/v1/openlibertyapplication_types.go
@@ -54,98 +54,102 @@ type OpenLibertyApplicationSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:order=8,type=spec,displayName="Expose",xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
 	Expose *bool `json:"expose,omitempty"`
 
-	// Enable management of LTPA key sharing amongst Liberty containers. Defaults to false.
+	// Enable management of password encryption key sharing amongst Liberty containers. Defaults to true.
 	// +operator-sdk:csv:customresourcedefinitions:order=9,type=spec,displayName="Manage LTPA",xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+	ManagePasswordEncryption *bool `json:"managePasswordEncryption,omitempty"`
+
+	// Enable management of LTPA key sharing amongst Liberty containers. Defaults to false.
+	// +operator-sdk:csv:customresourcedefinitions:order=10,type=spec,displayName="Manage LTPA",xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
 	ManageLTPA *bool `json:"manageLTPA,omitempty"`
 
 	// Enable management of TLS certificates. Defaults to true.
-	// +operator-sdk:csv:customresourcedefinitions:order=10,type=spec,displayName="Manage TLS",xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+	// +operator-sdk:csv:customresourcedefinitions:order=11,type=spec,displayName="Manage TLS",xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
 	ManageTLS *bool `json:"manageTLS,omitempty"`
 
 	// Number of pods to create. Defaults to 1. Not applicable when .spec.autoscaling or .spec.createKnativeService is specified.
-	// +operator-sdk:csv:customresourcedefinitions:order=11,type=spec,displayName="Replicas",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount"
+	// +operator-sdk:csv:customresourcedefinitions:order=12,type=spec,displayName="Replicas",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount"
 	Replicas *int32 `json:"replicas,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=12,type=spec,displayName="Auto Scaling"
+	// +operator-sdk:csv:customresourcedefinitions:order=13,type=spec,displayName="Auto Scaling"
 	Autoscaling *OpenLibertyApplicationAutoScaling `json:"autoscaling,omitempty"`
 
 	// Resource requests and limits for the application container.
-	// +operator-sdk:csv:customresourcedefinitions:order=13,type=spec,displayName="Resource Requirements",xDescriptors="urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+	// +operator-sdk:csv:customresourcedefinitions:order=14,type=spec,displayName="Resource Requirements",xDescriptors="urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=14,type=spec,displayName="Probes"
+	// +operator-sdk:csv:customresourcedefinitions:order=15,type=spec,displayName="Probes"
 	Probes *OpenLibertyApplicationProbes `json:"probes,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=15,type=spec,displayName="Deployment"
+	// +operator-sdk:csv:customresourcedefinitions:order=16,type=spec,displayName="Deployment"
 	Deployment *OpenLibertyApplicationDeployment `json:"deployment,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=16,type=spec,displayName="StatefulSet"
+	// +operator-sdk:csv:customresourcedefinitions:order=17,type=spec,displayName="StatefulSet"
 	StatefulSet *OpenLibertyApplicationStatefulSet `json:"statefulSet,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=17,type=spec,displayName="Service"
+	// +operator-sdk:csv:customresourcedefinitions:order=18,type=spec,displayName="Service"
 	Service *OpenLibertyApplicationService `json:"service,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=18,type=spec,displayName="Route"
+	// +operator-sdk:csv:customresourcedefinitions:order=19,type=spec,displayName="Route"
 	Route *OpenLibertyApplicationRoute `json:"route,omitempty"`
 
 	// Configures the Semeru Cloud Compiler to handle Just-In-Time (JIT) compilation requests from the application.
-	// +operator-sdk:csv:customresourcedefinitions:order=19,type=spec,displayName="Semeru Cloud Compiler"
+	// +operator-sdk:csv:customresourcedefinitions:order=20,type=spec,displayName="Semeru Cloud Compiler"
 	SemeruCloudCompiler *OpenLibertyApplicationSemeruCloudCompiler `json:"semeruCloudCompiler,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=20,type=spec,displayName="Network Policy"
+	// +operator-sdk:csv:customresourcedefinitions:order=21,type=spec,displayName="Network Policy"
 	NetworkPolicy *OpenLibertyApplicationNetworkPolicy `json:"networkPolicy,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=21,type=spec,displayName="Serviceability"
+	// +operator-sdk:csv:customresourcedefinitions:order=22,type=spec,displayName="Serviceability"
 	Serviceability *OpenLibertyApplicationServiceability `json:"serviceability,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=22,type=spec,displayName="Single Sign-On"
+	// +operator-sdk:csv:customresourcedefinitions:order=23,type=spec,displayName="Single Sign-On"
 	SSO *OpenLibertyApplicationSSO `json:"sso,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=23,type=spec,displayName="Monitoring"
+	// +operator-sdk:csv:customresourcedefinitions:order=24,type=spec,displayName="Monitoring"
 	Monitoring *OpenLibertyApplicationMonitoring `json:"monitoring,omitempty"`
 
 	// An array of environment variables for the application container.
 	// +listType=map
 	// +listMapKey=name
-	// +operator-sdk:csv:customresourcedefinitions:order=24,type=spec,displayName="Environment Variables"
+	// +operator-sdk:csv:customresourcedefinitions:order=25,type=spec,displayName="Environment Variables"
 	Env []corev1.EnvVar `json:"env,omitempty"`
 
 	// List of sources to populate environment variables in the application container.
 	// +listType=atomic
-	// +operator-sdk:csv:customresourcedefinitions:order=25,type=spec,displayName="Environment Variables from Sources"
+	// +operator-sdk:csv:customresourcedefinitions:order=26,type=spec,displayName="Environment Variables from Sources"
 	EnvFrom []corev1.EnvFromSource `json:"envFrom,omitempty"`
 
 	// Represents a volume with data that is accessible to the application container.
 	// +listType=map
 	// +listMapKey=name
-	// +operator-sdk:csv:customresourcedefinitions:order=26,type=spec,displayName="Volumes"
+	// +operator-sdk:csv:customresourcedefinitions:order=27,type=spec,displayName="Volumes"
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
 
 	// Represents where to mount the volumes into the application container.
 	// +listType=atomic
-	// +operator-sdk:csv:customresourcedefinitions:order=27,type=spec,displayName="Volume Mounts"
+	// +operator-sdk:csv:customresourcedefinitions:order=28,type=spec,displayName="Volume Mounts"
 	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
 
 	// List of containers to run before other containers in a pod.
 	// +listType=map
 	// +listMapKey=name
-	// +operator-sdk:csv:customresourcedefinitions:order=28,type=spec,displayName="Init Containers"
+	// +operator-sdk:csv:customresourcedefinitions:order=29,type=spec,displayName="Init Containers"
 	InitContainers []corev1.Container `json:"initContainers,omitempty"`
 
 	// List of sidecar containers. These are additional containers to be added to the pods.
 	// +listType=map
 	// +listMapKey=name
-	// +operator-sdk:csv:customresourcedefinitions:order=29,type=spec,displayName="Sidecar Containers"
+	// +operator-sdk:csv:customresourcedefinitions:order=30,type=spec,displayName="Sidecar Containers"
 	SidecarContainers []corev1.Container `json:"sidecarContainers,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=30,type=spec,displayName="Affinity"
+	// +operator-sdk:csv:customresourcedefinitions:order=31,type=spec,displayName="Affinity"
 	Affinity *OpenLibertyApplicationAffinity `json:"affinity,omitempty"`
 
 	// Security context for the application container.
-	// +operator-sdk:csv:customresourcedefinitions:order=31,type=spec,displayName="Security Context"
+	// +operator-sdk:csv:customresourcedefinitions:order=32,type=spec,displayName="Security Context"
 	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:order=32,type=spec,displayName="Topology Spread Constraints"
+	// +operator-sdk:csv:customresourcedefinitions:order=33,type=spec,displayName="Topology Spread Constraints"
 	TopologySpreadConstraints *OpenLibertyApplicationTopologySpreadConstraints `json:"topologySpreadConstraints,omitempty"`
 }
 
@@ -744,6 +748,11 @@ func (cr *OpenLibertyApplication) GetResourceConstraints() *corev1.ResourceRequi
 // GetExpose returns expose flag
 func (cr *OpenLibertyApplication) GetExpose() *bool {
 	return cr.Spec.Expose
+}
+
+// GetManagePasswordEncryption returns the Password Encryption key sharing status
+func (cr *OpenLibertyApplication) GetManagePasswordEncryption() *bool {
+	return cr.Spec.ManagePasswordEncryption
 }
 
 // GetManageLTPA returns the LTPA key sharing status

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -619,6 +619,11 @@ func (in *OpenLibertyApplicationSpec) DeepCopyInto(out *OpenLibertyApplicationSp
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ManagePasswordEncryption != nil {
+		in, out := &in.ManagePasswordEncryption, &out.ManagePasswordEncryption
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ManageLTPA != nil {
 		in, out := &in.ManageLTPA, &out.ManageLTPA
 		*out = new(bool)

--- a/bundle/manifests/apps.openliberty.io_openlibertyapplications.yaml
+++ b/bundle/manifests/apps.openliberty.io_openlibertyapplications.yaml
@@ -2464,6 +2464,10 @@ spec:
                 description: Enable management of LTPA key sharing amongst Liberty
                   containers. Defaults to false.
                 type: boolean
+              managePasswordEncryption:
+                description: Enable management of password encryption key sharing
+                  amongst Liberty containers. Defaults to true.
+                type: boolean
               manageTLS:
                 description: Enable management of TLS certificates. Defaults to true.
                 type: boolean

--- a/bundle/manifests/open-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/open-liberty.clusterserviceversion.yaml
@@ -92,7 +92,7 @@ metadata:
     categories: Application Runtime
     certified: "true"
     containerImage: icr.io/appcafe/open-liberty-operator:daily
-    createdAt: "2024-05-24T20:35:06Z"
+    createdAt: "2024-06-10T17:44:47Z"
     description: Deploy and manage containerized Liberty applications
     olm.skipRange: '>=0.8.0 <1.3.2'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
@@ -275,10 +275,10 @@ spec:
       - description: Specifies one or more scopes to request.
         displayName: Scope
         path: sso.oidc[0].scope
-      - description: Enable management of LTPA key sharing amongst Liberty containers.
-          Defaults to false.
+      - description: Enable management of password encryption key sharing amongst
+          Liberty containers. Defaults to true.
         displayName: Manage LTPA
-        path: manageLTPA
+        path: managePasswordEncryption
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: The port exposed by the container.
@@ -289,9 +289,10 @@ spec:
       - description: Specifies the required authentication method.
         displayName: Token Endpoint Auth Method
         path: sso.oidc[0].tokenEndpointAuthMethod
-      - description: Enable management of TLS certificates. Defaults to true.
-        displayName: Manage TLS
-        path: manageTLS
+      - description: Enable management of LTPA key sharing amongst Liberty containers.
+          Defaults to false.
+        displayName: Manage LTPA
+        path: manageLTPA
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - displayName: Service Type
@@ -304,29 +305,29 @@ spec:
         path: sso.oidc[0].hostNameVerificationEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Enable management of TLS certificates. Defaults to true.
+        displayName: Manage TLS
+        path: manageTLS
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Node proxies this port into your service.
+        displayName: Node Port
+        path: service.nodePort
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
       - description: Number of pods to create. Defaults to 1. Not applicable when
           .spec.autoscaling or .spec.createKnativeService is specified.
         displayName: Replicas
         path: replicas
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podCount
-      - description: Node proxies this port into your service.
-        displayName: Node Port
-        path: service.nodePort
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:number
-      - displayName: Auto Scaling
-        path: autoscaling
       - description: The name for the port exposed by the container.
         displayName: Port Name
         path: service.portName
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Resource requests and limits for the application container.
-        displayName: Resource Requirements
-        path: resources
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - displayName: Auto Scaling
+        path: autoscaling
       - description: Annotations to be added to the service.
         displayName: Service Annotations
         path: service.annotations
@@ -337,16 +338,19 @@ spec:
         path: service.certificate.annotations
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - displayName: Probes
-        path: probes
+      - description: Resource requests and limits for the application container.
+        displayName: Resource Requirements
+        path: resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: The port that the operator assigns to containers inside pods.
           Defaults to the value of .spec.service.port.
         displayName: Target Port
         path: service.targetPort
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - displayName: Deployment
-        path: deployment
+      - displayName: Probes
+        path: probes
       - description: 'A name of a secret that already contains TLS key, certificate
           and CA to be mounted in the pod. The following keys are valid in the secret:
           ca.crt, tls.crt, and tls.key.'
@@ -354,87 +358,89 @@ spec:
         path: service.certificateSecretRef
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Deployment
+        path: deployment
       - description: Configure service certificate.
         displayName: Service Certificate
         path: service.certificate
+      - description: An array consisting of service ports.
+        displayName: Ports
+        path: service.ports
       - displayName: StatefulSet
         path: statefulSet
       - displayName: Service
         path: service
-      - description: An array consisting of service ports.
-        displayName: Ports
-        path: service.ports
-      - displayName: Route
-        path: route
       - description: Expose the application as a bindable service. Defaults to false.
         displayName: Bindable
         path: service.bindable
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: Route
+        path: route
       - description: Configures the Semeru Cloud Compiler to handle Just-In-Time (JIT)
           compilation requests from the application.
         displayName: Semeru Cloud Compiler
         path: semeruCloudCompiler
-      - displayName: Network Policy
-        path: networkPolicy
       - description: Specifies the strategy to replace old deployment pods with new
           pods.
         displayName: Deployment Update Strategy
         path: deployment.updateStrategy
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:updateStrategy
+      - displayName: Network Policy
+        path: networkPolicy
       - displayName: Serviceability
         path: serviceability
       - displayName: Single Sign-On
         path: sso
-      - displayName: Monitoring
-        path: monitoring
       - description: Specifies the strategy to replace old StatefulSet pods with new
           pods.
         displayName: StatefulSet Update Strategy
         path: statefulSet.updateStrategy
+      - displayName: Monitoring
+        path: monitoring
+      - displayName: Storage
+        path: statefulSet.storage
       - description: An array of environment variables for the application container.
         displayName: Environment Variables
         path: env
-      - displayName: Storage
-        path: statefulSet.storage
-      - description: List of sources to populate environment variables in the application
-          container.
-        displayName: Environment Variables from Sources
-        path: envFrom
       - description: A convenient field to set the size of the persisted storage.
         displayName: Storage Size
         path: statefulSet.storage.size
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: List of sources to populate environment variables in the application
+          container.
+        displayName: Environment Variables from Sources
+        path: envFrom
       - description: A convenient field to request the storage class of the persisted
           storage. The name can not be specified or updated after the storage is created.
         displayName: Storage Class Name
         path: statefulSet.storage.className
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Represents a volume with data that is accessible to the application
-          container.
-        displayName: Volumes
-        path: volumes
       - description: The directory inside the container where this persisted storage
           will be bound to.
         displayName: Storage Mount Path
         path: statefulSet.storage.mountPath
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Represents where to mount the volumes into the application container.
-        displayName: Volume Mounts
-        path: volumeMounts
-      - description: List of containers to run before other containers in a pod.
-        displayName: Init Containers
-        path: initContainers
+      - description: Represents a volume with data that is accessible to the application
+          container.
+        displayName: Volumes
+        path: volumes
       - description: A YAML object that represents a volumeClaimTemplate component
           of a StatefulSet.
         displayName: Storage Volume Claim Template
         path: statefulSet.storage.volumeClaimTemplate
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:PersistentVolumeClaim
+      - description: Represents where to mount the volumes into the application container.
+        displayName: Volume Mounts
+        path: volumeMounts
+      - description: List of containers to run before other containers in a pod.
+        displayName: Init Containers
+        path: initContainers
       - description: List of sidecar containers. These are additional containers to
           be added to the pods.
         displayName: Sidecar Containers

--- a/config/crd/bases/apps.openliberty.io_openlibertyapplications.yaml
+++ b/config/crd/bases/apps.openliberty.io_openlibertyapplications.yaml
@@ -2460,6 +2460,10 @@ spec:
                 description: Enable management of LTPA key sharing amongst Liberty
                   containers. Defaults to false.
                 type: boolean
+              managePasswordEncryption:
+                description: Enable management of password encryption key sharing
+                  amongst Liberty containers. Defaults to true.
+                type: boolean
               manageTLS:
                 description: Enable management of TLS certificates. Defaults to true.
                 type: boolean

--- a/config/manifests/bases/open-liberty.clusterserviceversion.yaml
+++ b/config/manifests/bases/open-liberty.clusterserviceversion.yaml
@@ -187,10 +187,10 @@ spec:
       - description: Specifies one or more scopes to request.
         displayName: Scope
         path: sso.oidc[0].scope
-      - description: Enable management of LTPA key sharing amongst Liberty containers.
-          Defaults to false.
+      - description: Enable management of password encryption key sharing amongst
+          Liberty containers. Defaults to true.
         displayName: Manage LTPA
-        path: manageLTPA
+        path: managePasswordEncryption
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: The port exposed by the container.
@@ -201,9 +201,10 @@ spec:
       - description: Specifies the required authentication method.
         displayName: Token Endpoint Auth Method
         path: sso.oidc[0].tokenEndpointAuthMethod
-      - description: Enable management of TLS certificates. Defaults to true.
-        displayName: Manage TLS
-        path: manageTLS
+      - description: Enable management of LTPA key sharing amongst Liberty containers.
+          Defaults to false.
+        displayName: Manage LTPA
+        path: manageLTPA
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - displayName: Service Type
@@ -216,29 +217,29 @@ spec:
         path: sso.oidc[0].hostNameVerificationEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Enable management of TLS certificates. Defaults to true.
+        displayName: Manage TLS
+        path: manageTLS
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Node proxies this port into your service.
+        displayName: Node Port
+        path: service.nodePort
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
       - description: Number of pods to create. Defaults to 1. Not applicable when
           .spec.autoscaling or .spec.createKnativeService is specified.
         displayName: Replicas
         path: replicas
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podCount
-      - description: Node proxies this port into your service.
-        displayName: Node Port
-        path: service.nodePort
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:number
-      - displayName: Auto Scaling
-        path: autoscaling
       - description: The name for the port exposed by the container.
         displayName: Port Name
         path: service.portName
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Resource requests and limits for the application container.
-        displayName: Resource Requirements
-        path: resources
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - displayName: Auto Scaling
+        path: autoscaling
       - description: Annotations to be added to the service.
         displayName: Service Annotations
         path: service.annotations
@@ -249,16 +250,19 @@ spec:
         path: service.certificate.annotations
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - displayName: Probes
-        path: probes
+      - description: Resource requests and limits for the application container.
+        displayName: Resource Requirements
+        path: resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: The port that the operator assigns to containers inside pods.
           Defaults to the value of .spec.service.port.
         displayName: Target Port
         path: service.targetPort
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - displayName: Deployment
-        path: deployment
+      - displayName: Probes
+        path: probes
       - description: 'A name of a secret that already contains TLS key, certificate
           and CA to be mounted in the pod. The following keys are valid in the secret:
           ca.crt, tls.crt, and tls.key.'
@@ -266,87 +270,89 @@ spec:
         path: service.certificateSecretRef
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Deployment
+        path: deployment
       - description: Configure service certificate.
         displayName: Service Certificate
         path: service.certificate
+      - description: An array consisting of service ports.
+        displayName: Ports
+        path: service.ports
       - displayName: StatefulSet
         path: statefulSet
       - displayName: Service
         path: service
-      - description: An array consisting of service ports.
-        displayName: Ports
-        path: service.ports
-      - displayName: Route
-        path: route
       - description: Expose the application as a bindable service. Defaults to false.
         displayName: Bindable
         path: service.bindable
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: Route
+        path: route
       - description: Configures the Semeru Cloud Compiler to handle Just-In-Time (JIT)
           compilation requests from the application.
         displayName: Semeru Cloud Compiler
         path: semeruCloudCompiler
-      - displayName: Network Policy
-        path: networkPolicy
       - description: Specifies the strategy to replace old deployment pods with new
           pods.
         displayName: Deployment Update Strategy
         path: deployment.updateStrategy
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:updateStrategy
+      - displayName: Network Policy
+        path: networkPolicy
       - displayName: Serviceability
         path: serviceability
       - displayName: Single Sign-On
         path: sso
-      - displayName: Monitoring
-        path: monitoring
       - description: Specifies the strategy to replace old StatefulSet pods with new
           pods.
         displayName: StatefulSet Update Strategy
         path: statefulSet.updateStrategy
+      - displayName: Monitoring
+        path: monitoring
+      - displayName: Storage
+        path: statefulSet.storage
       - description: An array of environment variables for the application container.
         displayName: Environment Variables
         path: env
-      - displayName: Storage
-        path: statefulSet.storage
-      - description: List of sources to populate environment variables in the application
-          container.
-        displayName: Environment Variables from Sources
-        path: envFrom
       - description: A convenient field to set the size of the persisted storage.
         displayName: Storage Size
         path: statefulSet.storage.size
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: List of sources to populate environment variables in the application
+          container.
+        displayName: Environment Variables from Sources
+        path: envFrom
       - description: A convenient field to request the storage class of the persisted
           storage. The name can not be specified or updated after the storage is created.
         displayName: Storage Class Name
         path: statefulSet.storage.className
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Represents a volume with data that is accessible to the application
-          container.
-        displayName: Volumes
-        path: volumes
       - description: The directory inside the container where this persisted storage
           will be bound to.
         displayName: Storage Mount Path
         path: statefulSet.storage.mountPath
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Represents where to mount the volumes into the application container.
-        displayName: Volume Mounts
-        path: volumeMounts
-      - description: List of containers to run before other containers in a pod.
-        displayName: Init Containers
-        path: initContainers
+      - description: Represents a volume with data that is accessible to the application
+          container.
+        displayName: Volumes
+        path: volumes
       - description: A YAML object that represents a volumeClaimTemplate component
           of a StatefulSet.
         displayName: Storage Volume Claim Template
         path: statefulSet.storage.volumeClaimTemplate
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:PersistentVolumeClaim
+      - description: Represents where to mount the volumes into the application container.
+        displayName: Volume Mounts
+        path: volumeMounts
+      - description: List of containers to run before other containers in a pod.
+        displayName: Init Containers
+        path: initContainers
       - description: List of sidecar containers. These are additional containers to
           be added to the pods.
         displayName: Sidecar Containers

--- a/controllers/assets/encryption-mount.xml
+++ b/controllers/assets/encryption-mount.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <include location="ENCRYPTION_LOCATION" />
+</server>

--- a/controllers/assets/encryption.xml
+++ b/controllers/assets/encryption.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <variable name="wlp.password.encryption.key" value="WLP_PASSWORD_ENCRYPTION_KEY" />
+</server>

--- a/controllers/assets/ltpa.xml
+++ b/controllers/assets/ltpa.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <ltpa keysFileName="LTPA_KEYS_FILE_NAME" keysPassword="LTPA_KEYS_PASSWORD" />
+</server>

--- a/controllers/encryption_key_sharing.go
+++ b/controllers/encryption_key_sharing.go
@@ -1,0 +1,123 @@
+package controllers
+
+import (
+	"context"
+	"strings"
+
+	lutils "github.com/OpenLiberty/open-liberty-operator/utils"
+
+	olv1 "github.com/OpenLiberty/open-liberty-operator/api/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func (r *ReconcileOpenLiberty) reconcileEncryptionKeySharing(instance *olv1.OpenLibertyApplication) (string, string, error) {
+	// Does this Liberty application instance enable password encryption key sharing?
+	keySharingEnabled := r.isPasswordEncryptionKeySharingEnabled(instance)
+	if keySharingEnabled {
+		// Does the namespace already have a password encryption key sharing Secret?
+		encryptionSecret, err := r.hasEncryptionKeySecret(instance)
+		if err == nil {
+			// Is the password encryption key field in the Secret valid?
+			if encryptionKey := string(encryptionSecret.Data["passwordEncryptionKey"]); len(encryptionKey) > 0 {
+				// Create the Liberty config that will mount into the pods
+				err := r.createEncryptionKeyLibertyConfig(instance, encryptionKey)
+				if err != nil {
+					return "Failed to create Liberty resources to share the Encryption Key", encryptionSecret.Name, err
+				}
+				return "", encryptionSecret.Name, nil
+			}
+		}
+	}
+	// Delete the Liberty config that previously was mounted in the pod.
+	err := r.deleteEncryptionKeyResources(instance)
+	if err != nil {
+		return "Failed to delete Liberty resources sharing the old Encryption Key", "", err
+	}
+
+	return "", "", nil
+}
+
+func (r *ReconcileOpenLiberty) isPasswordEncryptionKeySharingEnabled(instance *olv1.OpenLibertyApplication) bool {
+	if instance.GetManagePasswordEncryption() == nil || *instance.GetManagePasswordEncryption() {
+		return true
+	}
+	return false
+}
+
+func (r *ReconcileOpenLiberty) hasEncryptionKeySecret(instance *olv1.OpenLibertyApplication) (*corev1.Secret, error) {
+	// The Secret that contains the password encryption key
+	passwordKeySecret := &corev1.Secret{}
+	passwordKeySecret.Name = OperatorShortName + lutils.PasswordEncryptionKeySuffix
+	passwordKeySecret.Namespace = instance.GetNamespace()
+	passwordKeySecret.Labels = lutils.GetRequiredLabels(passwordKeySecret.Name, "")
+	err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: passwordKeySecret.Name, Namespace: passwordKeySecret.Namespace}, passwordKeySecret)
+	return passwordKeySecret, err
+}
+
+// Gets the password encryption keys Secret and returns the name of the Secret storing its metadata
+func (r *ReconcileOpenLiberty) createEncryptionKeyLibertyConfig(instance *olv1.OpenLibertyApplication, encryptionKey string) error {
+	if len(encryptionKey) == 0 {
+		return nil
+	}
+
+	// The Secret to hold the server.xml that will override the password encryption key for the Liberty server
+	// This server.xml will be mounted in /output/resources/liberty-operator/encryptionKey.xml
+	encryptionXMLSecretName := OperatorShortName + lutils.ManagedEncryptionServerXML
+	encryptionXMLSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      encryptionXMLSecretName,
+			Namespace: instance.GetNamespace(),
+			Labels:    lutils.GetRequiredLabels(encryptionXMLSecretName, ""),
+		},
+	}
+	if err := r.CreateOrUpdate(encryptionXMLSecret, nil, func() error {
+		return lutils.CustomizeEncryptionKeyXML(encryptionXMLSecret, encryptionKey)
+	}); err != nil {
+		return err
+	}
+
+	// The Secret to hold the server.xml that will import the password encryption key into the Liberty server
+	// This server.xml will be mounted in /config/configDropins/overrides/encryptionKeyMount.xml
+	mountingXMLSecretName := OperatorShortName + lutils.ManagedEncryptionMountServerXML
+	mountingXMLSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mountingXMLSecretName,
+			Namespace: instance.GetNamespace(),
+			Labels:    lutils.GetRequiredLabels(mountingXMLSecretName, ""),
+		},
+	}
+	if err := r.CreateOrUpdate(mountingXMLSecret, nil, func() error {
+		mountDir := strings.Replace(lutils.SecureMountPath+"/"+lutils.EncryptionKeyXMLFileName, "/output", "${server.output.dir}", 1)
+		return lutils.CustomizeEncryptionKeyMountXML(mountingXMLSecret, mountDir)
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *ReconcileOpenLiberty) deleteEncryptionKeyResources(instance *olv1.OpenLibertyApplication) error {
+	// The Secret to hold the server.xml that will override the password encryption key for the Liberty server
+	// This server.xml will be mounted in /output/resources/liberty-operator/encryptionKey.xml
+	encryptionXMLSecret := &corev1.Secret{}
+	encryptionXMLSecret.Name = OperatorShortName + lutils.ManagedEncryptionServerXML
+	encryptionXMLSecret.Namespace = instance.GetNamespace()
+	err := r.DeleteResource(encryptionXMLSecret)
+	if err != nil {
+		return err
+	}
+
+	// The Secret to hold the server.xml that will import the password encryption key into the Liberty server
+	// This server.xml will be mounted in /config/configDropins/overrides/encryptionKeyMount.xml
+	mountingXMLSecret := &corev1.Secret{}
+	mountingXMLSecret.Name = OperatorShortName + lutils.ManagedEncryptionMountServerXML
+	mountingXMLSecret.Namespace = instance.GetNamespace()
+	err = r.DeleteResource(mountingXMLSecret)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/controllers/encryption_key_sharing.go
+++ b/controllers/encryption_key_sharing.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	lutils "github.com/OpenLiberty/open-liberty-operator/utils"
@@ -32,7 +33,7 @@ func (r *ReconcileOpenLiberty) reconcileEncryptionKeySharing(instance *olv1.Open
 	}
 	err := r.deleteEncryptionKeyResources(instance)
 	if err != nil {
-		return "Failed to delete Liberty resources for sharing the password encryption key", "", err
+		return "Failed to delete cluster resources for sharing the password encryption key", "", err
 	}
 	return "", "", nil
 }
@@ -86,7 +87,7 @@ func (r *ReconcileOpenLiberty) hasEncryptionKeySecret(instance *olv1.OpenLiberty
 // Gets the password encryption keys Secret and returns the name of the Secret storing its metadata
 func (r *ReconcileOpenLiberty) createEncryptionKeyLibertyConfig(instance *olv1.OpenLibertyApplication, encryptionKey string) error {
 	if len(encryptionKey) == 0 {
-		return nil
+		return fmt.Errorf("a password encryption key was not specified")
 	}
 
 	_, isEncryptionKeySharingLeader, _, err := r.getEncryptionKeySharingLeader(instance, true)

--- a/internal/deploy/kubectl/openliberty-app-crd.yaml
+++ b/internal/deploy/kubectl/openliberty-app-crd.yaml
@@ -2463,6 +2463,10 @@ spec:
                 description: Enable management of LTPA key sharing amongst Liberty
                   containers. Defaults to false.
                 type: boolean
+              managePasswordEncryption:
+                description: Enable management of password encryption key sharing
+                  amongst Liberty containers. Defaults to true.
+                type: boolean
               manageTLS:
                 description: Enable management of TLS certificates. Defaults to true.
                 type: boolean

--- a/internal/deploy/kustomize/daily/base/open-liberty-crd.yaml
+++ b/internal/deploy/kustomize/daily/base/open-liberty-crd.yaml
@@ -2463,6 +2463,10 @@ spec:
                 description: Enable management of LTPA key sharing amongst Liberty
                   containers. Defaults to false.
                 type: boolean
+              managePasswordEncryption:
+                description: Enable management of password encryption key sharing
+                  amongst Liberty containers. Defaults to true.
+                type: boolean
               manageTLS:
                 description: Enable management of TLS certificates. Defaults to true.
                 type: boolean

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -545,19 +545,19 @@ func isVolumeFound(pts *corev1.PodTemplateSpec, name string) bool {
 
 func ConfigurePasswordEncryption(pts *corev1.PodTemplateSpec, la *olv1.OpenLibertyApplication, operatorShortName string) {
 	// Mount a volume /output/resources/liberty-operator/encryptionKey.xml to store the Liberty Password Encryption Key
-	MountSecretAsVolume(pts, operatorShortName+ManagedEncryptionServerXML, GetVolumeMount(la, SecureMountPath, EncryptionKeyXMLFileName))
+	MountSecretAsVolume(pts, operatorShortName+ManagedEncryptionServerXML, CreateVolumeMount(SecureMountPath, EncryptionKeyXMLFileName))
 
-	// Mount a volume /config/configDropins/overrides/mountencryptionKey.xml to import the Liberty Password Encryption Key
-	MountSecretAsVolume(pts, operatorShortName+ManagedEncryptionMountServerXML, GetVolumeMount(la, overridesMountPath, EncryptionKeyMountXMLFileName))
+	// Mount a volume /config/configDropins/overrides/encryptionKeyMount.xml to import the Liberty Password Encryption Key
+	MountSecretAsVolume(pts, operatorShortName+ManagedEncryptionMountServerXML, CreateVolumeMount(overridesMountPath, EncryptionKeyMountXMLFileName))
 }
 
 // ConfigureLTPA setups the shared-storage for LTPA keys file generation
 func ConfigureLTPA(pts *corev1.PodTemplateSpec, la *olv1.OpenLibertyApplication, operatorShortName string) {
 	// Mount a volume /config/ltpa to store the ltpa.keys file
-	MountSecretAsVolume(pts, operatorShortName+"-managed-ltpa", GetVolumeMount(la, managedLTPAMountPath, ltpaKeysFileName))
+	MountSecretAsVolume(pts, operatorShortName+"-managed-ltpa", CreateVolumeMount(managedLTPAMountPath, ltpaKeysFileName))
 
 	// Mount a volume /config/configDropins/overrides/ltpa.xml to store the Liberty Server XML
-	MountSecretAsVolume(pts, operatorShortName+LTPAServerXMLSuffix, GetVolumeMount(la, overridesMountPath, ltpaXMLFileName))
+	MountSecretAsVolume(pts, operatorShortName+LTPAServerXMLSuffix, CreateVolumeMount(overridesMountPath, ltpaXMLFileName))
 }
 
 func MountSecretAsVolume(pts *corev1.PodTemplateSpec, secretName string, volumeMount corev1.VolumeMount) {
@@ -716,7 +716,7 @@ func parseMountName(fileName string) string {
 	return mountName
 }
 
-func GetVolumeMount(la *olv1.OpenLibertyApplication, mountPath string, fileName string) corev1.VolumeMount {
+func CreateVolumeMount(mountPath string, fileName string) corev1.VolumeMount {
 	return corev1.VolumeMount{
 		Name:      parseMountName(fileName),
 		MountPath: mountPath + "/" + fileName,


### PR DESCRIPTION
- This change adds the field `.spec.managePasswordEncryption` (default is `true`) which enables the operator to query whether or not a Secret `olo-wlp-password-encryption-key` with key `passwordEncryptionKey` exists, and if that Secret exists, the operator will restart all running Liberty servers to mount and set the `wlp.password.encryption.key` variable into each pod.
- Set `.spec.managePasswordEncryption` to `false` to disable the above functionality on a per-app basis.
- When `.spec.manageLTPA` is `true`, the operator will detect changes to the password encryption Secret and reload LTPA key generation, so that the new LTPA key is generated using the password encryption key.