### PR TITLE
Don't create certs with common name longer than 64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OpenLiberty/open-liberty-operator
 go 1.21
 
 require (
-	github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20240709193912-5bf349989171
+	github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20240711175518-f7c22478a03c
 	github.com/cert-manager/cert-manager v1.11.5
 	github.com/go-logr/logr v1.2.4
 	github.com/openshift/api v0.0.0-20230928134114-673ed0cfc7f1

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20240709193912-5bf349989171 h1:+6mXKupf/5t5MZqDMmYLNWUlYxp1lHJw2MKJe1GgdQs=
 github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20240709193912-5bf349989171/go.mod h1:WT5NclAsVyi4i74Iq+jQPSCDEB30wKhwc6mWEN74zeo=
+github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20240711175518-f7c22478a03c h1:KlSE9/6ra/DXz1zOABEy/akRzyGs7C+k+hh+TNXGwIs=
+github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20240711175518-f7c22478a03c/go.mod h1:WT5NclAsVyi4i74Iq+jQPSCDEB30wKhwc6mWEN74zeo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=


### PR DESCRIPTION
Fix picked up from latest version of RCO

To deal with issue
https://github.com/WASdev/websphere-liberty-operator/issues/655