### PR TITLE
Update Observability docs for 4.16

### DIFF
--- a/doc/observability-deployment.adoc
+++ b/doc/observability-deployment.adoc
@@ -1,6 +1,6 @@
 = Observability with Open Liberty
 
-The following document covers various topics for configuring and integrating your Open Liberty runtime with monitoring tools in a Kubernetes environment. This document has been tested and is supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12, 4.14, and 4.15.
+The following document covers various topics for configuring and integrating your Open Liberty runtime with monitoring tools in a Kubernetes environment. This document has been tested and is supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12, 4.14, 4.15, and 4.16.
 
 == How to analyze Open Liberty logs
 

--- a/doc/openshift-logging-rhocp_4.7+.adoc
+++ b/doc/openshift-logging-rhocp_4.7+.adoc
@@ -1,6 +1,6 @@
 # Application Logging on Red Hat OpenShift Container Platform (RHOCP) with Elasticsearch, Fluentd, and Kibana 
 
-The following guide has been tested and is supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12, 4.14, and 4.15.
+The following guide has been tested and is supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12, 4.14, 4.15, and 4.16.
 
 Pod processes running in Kubernetes frequently produce logs. To effectively manage this log data and ensure no loss of log data occurs when a pod terminates, a log aggregation tool should be deployed on the Kubernetes cluster. Log aggregation tools help users persist, search, and visualize the log data that is gathered from the pods across the cluster. Log aggregation tools in the market today include:  EFK, LogDNA, Splunk, Datadog, IBM Operations Analytics, etc.  When considering log aggregation tools, enterprises make choices that are inclusive of their journey to cloud, both new cloud-native applications running in Kubernetes and their existing traditional IT choices.
 
@@ -8,7 +8,7 @@ One choice for application logging with log aggregation, based on open source, i
 
 ## Install Openshift Logging
 
-To install the Openshift Logging component, follow the OpenShift guide  link:++https://docs.openshift.com/container-platform/4.15/logging/cluster-logging-deploying.html++[Installing Openshift Logging]. OpenShift now provides two log store options: the OpenShift Elasticsearch Operator (that is used in this guide) and the Loki Operator. Before deploying the example Cluster Logging instance YAML in the guide, install the OpenShift Elasticsearch Operator into all namespaces in your cluster.
+To install the Openshift Logging component, follow the OpenShift guide  link:++https://docs.openshift.com/container-platform/4.16/observability/logging/cluster-logging-deploying.html++[Installing Openshift Logging]. OpenShift now provides two log store options: the OpenShift Elasticsearch Operator (that is used in this guide) and the Loki Operator. Before deploying the example Cluster Logging instance YAML in the guide, install the OpenShift Elasticsearch Operator into all namespaces in your cluster.
 
 Ensure you set up valid storage for Elasticsearch via Persistent Volumes. When the example Cluster Logging instance YAML from the guide is deployed, the Elasticsearch pods that are created automatically search for Persistent Volumes to bind to; if there are none available for binding, the Elasticsearch pods are stuck in a pending state. Using in-memory storage is also possible by removing the `storage` definition from the Openshift Logging instance YAML, but this is not suitable for production.
 
@@ -108,7 +108,7 @@ Deploy the Cluster Log Forwarder instance with the following command:
 oc create -f cluster-logging-forwarder.yaml
 ----
 
-For more information on parsing JSON logs in RHOCP, see the the OpenShift guide link:++https://docs.openshift.com/container-platform/4.15/logging/log_collection_forwarding/cluster-logging-enabling-json-logging.html++[Enabling JSON logging].
+For more information on parsing JSON logs in RHOCP, see the the OpenShift guide link:++https://docs.openshift.com/container-platform/4.16/observability/logging/log_collection_forwarding/cluster-logging-enabling-json-logging.html++[Enabling JSON logging].
 
 ## View application logs in Kibana
 

--- a/doc/openshift-monitoring.adoc
+++ b/doc/openshift-monitoring.adoc
@@ -1,6 +1,6 @@
 # Application Monitoring on Red Hat OpenShift Container Platform (RHOCP) with Prometheus and Grafana
 
-The following guide has been tested and is supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12, 4.14, and 4.15.
+The following guide has been tested and is supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12, 4.14, 4.15, and 4.16.
 
 ## Prerequisites
 
@@ -14,9 +14,9 @@ In RHOCP 4.6+, application monitoring can be set up by enabling monitoring for u
 
 There is no separate Grafana deployment that comes with enabling user-defined monitoring and the existing Grafana instance provided with the default monitoring stack is read-only, so a community-powered Grafana Operator must be installed later to create custom dashboards for viewing your metrics.
 
-. To configure the monitoring stack, follow this OpenShift guide link:++https://docs.openshift.com/container-platform/4.15/monitoring/configuring-the-monitoring-stack.html#preparing-to-configure-the-monitoring-stack++[Configuring the monitoring stack]. Here, you will create two config maps, `cluster-monitoring-config` and `user-workload-monitoring-config`, that will allow you to enable monitoring for user-defined projects in the next step. After creating the `user-workload-monitoring-config` config map, return to this guide to continue setting up monitoring for user-defined projects.
+. To configure the monitoring stack, follow this OpenShift guide link:++https://docs.openshift.com/container-platform/4.16/observability/monitoring/configuring-the-monitoring-stack.html#preparing-to-configure-the-monitoring-stack++[Configuring the monitoring stack]. Here, you will create two config maps, `cluster-monitoring-config` and `user-workload-monitoring-config`, that will allow you to enable monitoring for user-defined projects in the next step. After creating the `user-workload-monitoring-config` config map, return to this guide to continue setting up monitoring for user-defined projects.
 
-. To enable monitoring for user-defined projects, follow the OpenShift guide link:++https://docs.openshift.com/container-platform/4.15/monitoring/enabling-monitoring-for-user-defined-projects.html++[Enabling monitoring for user-defined projects].
+. To enable monitoring for user-defined projects, follow the OpenShift guide link:++https://docs.openshift.com/container-platform/4.16/observability/monitoring/enabling-monitoring-for-user-defined-projects.html++[Enabling monitoring for user-defined projects].
 
 . Deploy a Service Monitor inside the `myapp` namespace to define the service endpoint that will be monitored by the Prometheus instance. Add the following YAML to your OpenLibertyApplication Custom Resource (CR):
 


### PR DESCRIPTION
Updating the Observability docs for 4.16.

Mainly version testing updates and link updates.

The switch from using the EFK stack to Loki/Vector/OCP console visualizations will be addressed in a different issue, since the solution is more involved.