### PR TITLE
Add consistent label to LTPA Jobs

### DIFF
--- a/internal/controller/ltpa_keys_sharing.go
+++ b/internal/controller/ltpa_keys_sharing.go
@@ -445,7 +445,7 @@ func (r *ReconcileOpenLiberty) generateLTPAKeys(instance *olv1.OpenLibertyApplic
 							EncryptionKeySecretName:     lutils.LocalPasswordEncryptionKeyRootName + passwordEncryptionMetadata.Name + "-internal",
 							EncryptionKeySharingEnabled: r.isUsingPasswordEncryptionKeySharing(instance, passwordEncryptionMetadata), // fix LTPA to use the default password encryption key (no suffix)
 						}
-						lutils.CustomizeLTPAKeysJob(generateLTPAKeysJob, instance, ltpaConfig, r.GetClient())
+						lutils.CustomizeLTPAKeysJob(generateLTPAKeysJob, generateLTPAKeysJobRootName, instance, ltpaConfig, r.GetClient())
 						return nil
 					})
 					if err != nil {
@@ -780,7 +780,7 @@ func (r *ReconcileOpenLiberty) generateLTPAConfig(instance *olv1.OpenLibertyAppl
 								EncryptionKeySecretName:     lutils.LocalPasswordEncryptionKeyRootName + passwordEncryptionMetadata.Name + "-internal",
 								EncryptionKeySharingEnabled: r.isUsingPasswordEncryptionKeySharing(instance, passwordEncryptionMetadata), // fix LTPA to use the default password encryption key (no suffix)
 							}
-							lutils.CustomizeLTPAConfigJob(generateLTPAConfigJob, instance, ltpaConfig, r.GetClient())
+							lutils.CustomizeLTPAConfigJob(generateLTPAConfigJob, generateLTPAConfigJobRootName, instance, ltpaConfig, r.GetClient())
 							return nil
 						})
 						if err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -828,10 +828,11 @@ func IsLTPAJobConfigurationOutdated(job *v1.Job, appLeaderInstance *olv1.OpenLib
 	return false
 }
 
-func CustomizeLTPAKeysJob(job *v1.Job, la *olv1.OpenLibertyApplication, ltpaConfig *LTPAConfig, client client.Client) {
+func CustomizeLTPAKeysJob(job *v1.Job, jobRootName string, la *olv1.OpenLibertyApplication, ltpaConfig *LTPAConfig, client client.Client) {
 	ltpaVolumeMountName := parseMountName(ltpaConfig.FileName)
 	encodingType := "aes" // the password encoding type for securityUtility (one of "xor", "aes", or "hash")
 	job.Spec.Template.ObjectMeta.Name = "liberty"
+	job.Spec.Template.ObjectMeta.Labels = GetRequiredLabels(jobRootName, job.Name)
 	job.Spec.Template.Spec.Containers = []corev1.Container{
 		{
 			Name:            job.Spec.Template.ObjectMeta.Name,
@@ -884,10 +885,11 @@ func CustomizeLTPAKeysJob(job *v1.Job, la *olv1.OpenLibertyApplication, ltpaConf
 	})
 }
 
-func CustomizeLTPAConfigJob(job *v1.Job, la *olv1.OpenLibertyApplication, ltpaConfig *LTPAConfig, client client.Client) {
+func CustomizeLTPAConfigJob(job *v1.Job, jobRootName string, la *olv1.OpenLibertyApplication, ltpaConfig *LTPAConfig, client client.Client) {
 	ltpaVolumeMountName := parseMountName(ltpaConfig.FileName)
 	encodingType := "aes" // the password encoding type for securityUtility (one of "xor", "aes", or "hash")
 	job.Spec.Template.ObjectMeta.Name = "liberty"
+	job.Spec.Template.ObjectMeta.Labels = GetRequiredLabels(jobRootName, job.Name)
 	job.Spec.Template.Spec.Containers = []corev1.Container{
 		{
 			Name:            job.Spec.Template.ObjectMeta.Name,


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Adds a consistent labelling `app.kubernetes.io/name: olo-managed-ltpa-config-generation` and `app.kubernetes.io/name: olo-managed-ltpa-generation` to the LTPA config and key Jobs, respectively.

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
