### PR TITLE
Add logging levels to reduce default log output

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,6 +35,7 @@ import (
 	openlibertyv1 "github.com/OpenLiberty/open-liberty-operator/api/v1"
 	"github.com/OpenLiberty/open-liberty-operator/internal/controller"
 
+	"github.com/application-stacks/runtime-component-operator/common"
 	"github.com/application-stacks/runtime-component-operator/utils"
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	imagev1 "github.com/openshift/api/image/v1"
@@ -79,7 +80,14 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	utils.CreateConfigMap(controller.OperatorName)
+
+	opts := zap.Options{
+		Level:           common.LevelFunc,
+		StacktraceLevel: common.StackLevelFunc,
+		Development:     true,
+	}
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	// see https://github.com/operator-framework/operator-sdk/issues/1813
 	leaseDuration := 30 * time.Second
@@ -152,8 +160,6 @@ func main() {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
-
-	utils.CreateConfigMap(controller.OperatorName)
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OpenLiberty/open-liberty-operator
 go 1.23
 
 require (
-	github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20241118182902-2340c1cdeff2
+	github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20241120210837-2650f9d4b763
 	github.com/cert-manager/cert-manager v1.13.6
 	github.com/go-logr/logr v1.3.0
 	github.com/openshift/api v0.0.0-20230928134114-673ed0cfc7f1

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d h
 contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d/go.mod h1:IshRmMJBhDfFj5Y67nVhMYTTIze91RUeT73ipWKs/GY=
 contrib.go.opencensus.io/exporter/prometheus v0.4.2 h1:sqfsYl5GIY/L570iT+l93ehxaWJs2/OwXtiWwew3oAg=
 contrib.go.opencensus.io/exporter/prometheus v0.4.2/go.mod h1:dvEHbiKmgvbr5pjaF9fpw1KeYcjrnC1J8B+JKjsZyRQ=
-github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20241118182902-2340c1cdeff2 h1:dv5rxcqVkCFbWtH4N4U8AA7M284DXhXgC3eEls2KETk=
-github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20241118182902-2340c1cdeff2/go.mod h1:Q//a3yubxjR3+COorasymYRuuiDPs0Usgl9YuADkD6U=
+github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20241120210837-2650f9d4b763 h1:qs+ovAwqaRrx2MTvtM8Elc3anZNUNBDah3KwDeNabb8=
+github.com/application-stacks/runtime-component-operator v1.0.0-20220602-0850.0.20241120210837-2650f9d4b763/go.mod h1:Q//a3yubxjR3+COorasymYRuuiDPs0Usgl9YuADkD6U=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/internal/controller/openlibertyapplication_controller.go
+++ b/internal/controller/openlibertyapplication_controller.go
@@ -71,6 +71,7 @@ const applicationFinalizer = "finalizer.openlibertyapplications.apps.openliberty
 // move the current state of the cluster closer to the desired state.
 func (r *ReconcileOpenLiberty) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	reqLogger := r.Log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqDebugLogger := reqLogger.V(common.LogLevelDebug)
 	reqLogger.Info("Reconcile OpenLibertyApplication - starting")
 	ns, err := oputils.GetOperatorNamespace()
 	if err != nil {
@@ -313,7 +314,7 @@ func (r *ReconcileOpenLiberty) Reconcile(ctx context.Context, request ctrl.Reque
 	// Check if SemeruCloudCompiler is enabled before reconciling the Semeru Compiler deployment and service.
 	// Otherwise, delete the Semeru Compiler deployment and service.
 	message := "Start Semeru Compiler reconcile"
-	reqLogger.Info(message)
+	reqDebugLogger.Info(message)
 	err, message, areCompletedSemeruInstancesMarkedToBeDeleted := r.reconcileSemeruCompiler(instance)
 	if err != nil {
 		reqLogger.Error(err, message)


### PR DESCRIPTION
Part of #638
Picks up latest RCO for log level framework, and moves 'semeru start' log messages to debug level