### PR TITLE
Document .spec.serviceAccount.name limitations

### DIFF
--- a/doc/user-guide-v1.adoc
+++ b/doc/user-guide-v1.adoc
@@ -844,7 +844,7 @@ The Liberty server must allow configuration drop-ins. The following configuratio
 [[create-a-service-account]]
 === Configure a service account (`.spec.serviceAccount`)
 
-The operator can create a `ServiceAccount` resource when deploying an `OpenLibertyApplication` custom resource (CR). If `.spec.serviceAccount.name` is **not** specified in a CR, the operator creates a service account with the same name as the CR (e.g. `my-app`). In addition, this service account is dynamically updated when changes are detected to the CR field for `.spec.pullSecret`.
+The operator can create a `ServiceAccount` resource when deploying an `OpenLibertyApplication` custom resource (CR). If `.spec.serviceAccount.name` is **not** specified in a CR, the operator creates a service account with the same name as the CR (e.g. `my-app`). In addition, this service account is dynamically updated when pull secret changes are detected in the CR field `.spec.pullSecret`.
 
 Alternatively, the operator can use a custom ServiceAccount that you provide. If `.spec.serviceAccount.name` is specified in a CR, the operator uses the service account as is (i.e. read-only) when provisioning new Pods. It is your responsibility to add any required image pull secrets to the service account when accessing images behind a private registry.
 

--- a/doc/user-guide-v1.adoc
+++ b/doc/user-guide-v1.adoc
@@ -844,7 +844,9 @@ The Liberty server must allow configuration drop-ins. The following configuratio
 [[create-a-service-account]]
 === Configure a service account (`.spec.serviceAccount`)
 
-The operator can create a `ServiceAccount` resource when deploying an `OpenLibertyApplication` custom resource (CR). If `.spec.serviceAccount.name` is not specified in a CR, the operator creates a service account with the same name as the CR (e.g. `my-app`).
+The operator can create a `ServiceAccount` resource when deploying an `OpenLibertyApplication` custom resource (CR). If `.spec.serviceAccount.name` is **not** specified in a CR, the operator creates a service account with the same name as the CR (e.g. `my-app`). In addition, this service account is dynamically updated when changes are detected to the CR field for `.spec.pullSecret`.
+
+Alternatively, the operator can use a custom ServiceAccount that you provide. If `.spec.serviceAccount.name` is specified in a CR, the operator uses the service account as is (i.e. read-only) when provisioning new Pods. It is your responsibility to add any required image pull secrets to the service account when accessing images behind a private registry.
 
 NOTE: `.spec.serviceAccountName` is now deprecated. The operator still looks up the value of `.spec.serviceAccountName`, but you must switch to using `.spec.serviceAccount.name`.
 

--- a/internal/controller/openlibertyapplication_controller.go
+++ b/internal/controller/openlibertyapplication_controller.go
@@ -296,21 +296,10 @@ func (r *ReconcileOpenLiberty) Reconcile(ctx context.Context, request ctrl.Reque
 				return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
 			}
 		} else {
-			// a custom SA is being used so delete the default SA, if it exists
 			serviceAccount := &corev1.ServiceAccount{ObjectMeta: defaultMeta}
 			err = r.DeleteResource(serviceAccount)
 			if err != nil {
 				reqLogger.Error(err, "Failed to delete ServiceAccount")
-				return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
-			}
-
-			// customize the custom SA with operator labels and known image pull secrets
-			customServiceAccount := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: serviceAccountName, Namespace: instance.Namespace}}
-			err = r.CreateOrUpdate(customServiceAccount, instance, func() error {
-				return oputils.CustomizeServiceAccount(customServiceAccount, instance, r.GetClient())
-			})
-			if err != nil {
-				reqLogger.Error(err, "Failed to reconcile custom ServiceAccount")
 				return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Resolves https://github.com/OpenLiberty/open-liberty-operator/issues/668
- avoids confusion when switching between custom and operator-created service accounts
    - mention that the operator-created service account is dynamically updated (i.e. checks .spec.pullSecret)
    - mention that the user-provided service account will be treated as read-only

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
