### PR TITLE
adding back 4.12 as it is still in extended support

### DIFF
--- a/doc/observability-deployment.adoc
+++ b/doc/observability-deployment.adoc
@@ -1,6 +1,6 @@
 = Observability with Open Liberty
 
-The following document covers various topics for configuring and integrating your Open Liberty runtime with monitoring tools in a Kubernetes environment. This document has been tested and is supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.14, 4.16, 4.17, 4.18, and 4.19.
+The following document covers various topics for configuring and integrating your Open Liberty runtime with monitoring tools in a Kubernetes environment. This document has been tested and is supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12, 4.14, 4.16, 4.17, 4.18, and 4.19.
 
 == How to analyze Open Liberty logs
 
@@ -18,7 +18,7 @@ Retrieve available Kibana dashboards for displaying Open Liberty logging events 
 
 For information regarding how to import Kibana dashboards see the official documentation link:++https://www.elastic.co/guide/en/kibana/current/dashboard.html++[here].
 
-For effective management of logs emitted from applications, deploy your own Elasticsearch, Fluentd and Kibana (EFK) stack. If you are deploying the EFK stack on OpenShift, see the following link:openshift-logging-rhocp_4.7-4.16.adoc[guide]. Note: The instructions in the guide for deploying the EFK stack on OpenShift are only valid up to RHOCP version 4.16.
+For effective management of logs emitted from applications, deploy your own Elasticsearch, Fluentd and Kibana (EFK) stack. If you are deploying the EFK stack on OpenShift, see the following link:openshift-logging-rhocp_4.12-4.16.adoc[guide]. Note: The instructions in the guide for deploying the EFK stack on OpenShift are only valid up to RHOCP version 4.16.
 
 === Application logging with Loki and Vector
 

--- a/doc/openshift-logging-rhocp_4.12-4.16.adoc
+++ b/doc/openshift-logging-rhocp_4.12-4.16.adoc
@@ -1,6 +1,6 @@
 # Application Logging on Red Hat OpenShift Container Platform (RHOCP) with Elasticsearch, Fluentd, and Kibana 
 
-The following guide has been tested and is supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.14 and 4.16.
+The following guide has been tested and is supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12, 4.14 and 4.16.
 
 Pod processes running in Kubernetes frequently produce logs. To effectively manage this log data and ensure no loss of log data occurs when a pod terminates, a log aggregation tool should be deployed on the Kubernetes cluster. Log aggregation tools help users persist, search, and visualize the log data that is gathered from the pods across the cluster. Log aggregation tools in the market today include:  EFK, LogDNA, Splunk, Datadog, IBM Operations Analytics, etc.  When considering log aggregation tools, enterprises make choices that are inclusive of their journey to cloud, both new cloud-native applications running in Kubernetes and their existing traditional IT choices.
 

--- a/doc/openshift-monitoring.adoc
+++ b/doc/openshift-monitoring.adoc
@@ -1,6 +1,6 @@
 # Application Monitoring on Red Hat OpenShift Container Platform (RHOCP) with Prometheus and Grafana
 
-The following guide has been tested and is supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.14, 4.16, 4.17, 4.18 and 4.19.
+The following guide has been tested and is supported with Red Hat OpenShift Container Platform (RHOCP) versions 4.12, 4.14, 4.16, 4.17, 4.18 and 4.19.
 
 ## Prerequisites
 
@@ -8,9 +8,9 @@ Prior to installing application monitoring on RHOCP, ensure that there is a runn
 
 This guide assumes a running application has been deployed to the RHOCP cluster inside a project/namespace called `myapp`, and that its Prometheus metrics endpoint is exposed on path `/metrics`.
 
-# Application Monitoring on RHOCP 4.14+
+# Application Monitoring on RHOCP 4.12+
 
-In RHOCP 4.14+, application monitoring can be set up by enabling monitoring for user-defined projects without the need to install an additional monitoring solution. This solution will deploy a second Prometheus Operator instance inside the `openshift-user-workload-monitoring` namespace that is configured to monitor all namespaces excluding the `openshift-` prefixed namespaces already monitored by the cluster's default platform monitoring.
+In RHOCP 4.12+, application monitoring can be set up by enabling monitoring for user-defined projects without the need to install an additional monitoring solution. This solution will deploy a second Prometheus Operator instance inside the `openshift-user-workload-monitoring` namespace that is configured to monitor all namespaces excluding the `openshift-` prefixed namespaces already monitored by the cluster's default platform monitoring.
 
 There is no separate Grafana deployment that comes with enabling user-defined monitoring and the existing Grafana instance provided with the default monitoring stack is read-only, so a community-powered Grafana Operator must be installed later to create custom dashboards for viewing your metrics.
 


### PR DESCRIPTION
**What this PR does / why we need it?**:

- need to add back 4.12 references as it is still in extended support

**Does this PR introduce a user-facing change?**
- [ ] User guide
- [ ] `CHANGELOG.md`