### PR TITLE
Add error messages to performance data feature 

### DIFF
--- a/api/v1/openlibertyperformancedata_types.go
+++ b/api/v1/openlibertyperformancedata_types.go
@@ -139,7 +139,7 @@ func (c *OperationStatusCondition) SetReason(r string) {
 }
 
 // GetStatus return condition's status
-func (cr *OpenLibertyTrace) GetStatus() *OpenLibertyPerformanceDataStatus {
+func (cr *OpenLibertyPerformanceData) GetStatus() *OpenLibertyPerformanceDataStatus {
 	return &cr.Status
 }
 

--- a/api/v1/openlibertyperformancedata_types.go
+++ b/api/v1/openlibertyperformancedata_types.go
@@ -1,6 +1,9 @@
 package v1
 
 import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -66,10 +69,6 @@ type OpenLibertyPerformanceDataList struct {
 	Items           []OpenLibertyPerformanceData `json:"items"`
 }
 
-func init() {
-	SchemeBuilder.Register(&OpenLibertyPerformanceData{}, &OpenLibertyPerformanceDataList{})
-}
-
 func getIntValueOrDefault(value *int, defaultValue int) int {
 	if value == nil {
 		return defaultValue
@@ -87,4 +86,123 @@ func (cr *OpenLibertyPerformanceData) GetTimespan() int {
 func (cr *OpenLibertyPerformanceData) GetInterval() int {
 	defaultInterval := 30
 	return getIntValueOrDefault(cr.Spec.Interval, defaultInterval)
+}
+
+// GetType returns status condition type
+func (c *OperationStatusCondition) GetType() OperationStatusConditionType {
+	return c.Type
+}
+
+// SetType sets status condition type
+func (c *OperationStatusCondition) SetType(ct OperationStatusConditionType) {
+	c.Type = ct
+}
+
+// GetLastTransitionTime return time of last status change
+func (c *OperationStatusCondition) GetLastTransitionTime() *metav1.Time {
+	return c.LastTransitionTime
+}
+
+// SetLastTransitionTime sets time of last status change
+func (c *OperationStatusCondition) SetLastTransitionTime(t *metav1.Time) {
+	c.LastTransitionTime = t
+}
+
+// GetLastUpdateTime return time of last status update
+func (c *OperationStatusCondition) GetLastUpdateTime() metav1.Time {
+	return c.LastUpdateTime
+}
+
+// SetLastUpdateTime sets time of last status update
+func (c *OperationStatusCondition) SetLastUpdateTime(t metav1.Time) {
+	c.LastUpdateTime = t
+}
+
+// GetMessage return condition's message
+func (c *OperationStatusCondition) GetMessage() string {
+	return c.Message
+}
+
+// SetMessage sets condition's message
+func (c *OperationStatusCondition) SetMessage(m string) {
+	c.Message = m
+}
+
+// GetReason return condition's message
+func (c *OperationStatusCondition) GetReason() string {
+	return c.Reason
+}
+
+// SetReason sets condition's reason
+func (c *OperationStatusCondition) SetReason(r string) {
+	c.Reason = r
+}
+
+// GetStatus return condition's status
+func (cr *OpenLibertyTrace) GetStatus() *OpenLibertyPerformanceDataStatus {
+	return &cr.Status
+}
+
+// GetStatus return condition's status
+func (c *OperationStatusCondition) GetStatus() corev1.ConditionStatus {
+	return c.Status
+}
+
+// SetStatus sets condition's status
+func (c *OperationStatusCondition) SetStatus(s corev1.ConditionStatus) {
+	c.Status = s
+}
+
+// NewCondition returns new condition
+func (s *OpenLibertyPerformanceDataStatus) NewCondition() OperationStatusCondition {
+	return OperationStatusCondition{}
+}
+
+// GetConditions returns slice of conditions
+func (s *OpenLibertyPerformanceDataStatus) GetConditions() []OperationStatusCondition {
+	var conditions = []OperationStatusCondition{}
+	for i := range s.Conditions {
+		conditions[i] = s.Conditions[i]
+	}
+	return conditions
+}
+
+// GetCondition ...
+func (s *OpenLibertyPerformanceDataStatus) GetCondition(t OperationStatusConditionType) OperationStatusCondition {
+
+	for i := range s.Conditions {
+		if s.Conditions[i].GetType() == t {
+			return s.Conditions[i]
+		}
+	}
+	return OperationStatusCondition{LastUpdateTime: metav1.Time{}} //revisit
+}
+
+// SetCondition ...
+func (s *OpenLibertyPerformanceDataStatus) SetCondition(c OperationStatusCondition) {
+	condition := &OperationStatusCondition{}
+	found := false
+	for i := range s.Conditions {
+		if s.Conditions[i].GetType() == c.GetType() {
+			condition = &s.Conditions[i]
+			found = true
+			break
+		}
+	}
+
+	if condition.GetStatus() != c.GetStatus() || condition.GetMessage() != c.GetMessage() || condition.GetReason() != c.GetReason() {
+		condition.SetLastTransitionTime(&metav1.Time{Time: time.Now()})
+	}
+
+	condition.SetReason(c.GetReason())
+	condition.SetMessage(c.GetMessage())
+	condition.SetStatus(c.GetStatus())
+	condition.SetType(c.GetType())
+	if !found {
+		s.Conditions = append(s.Conditions, *condition)
+	}
+}
+
+func init() {
+	SchemeBuilder.Register(&OpenLibertyPerformanceData{}, &OpenLibertyPerformanceDataList{})
 }

--- a/api/v1/openlibertyperformancedata_types.go
+++ b/api/v1/openlibertyperformancedata_types.go
@@ -3,7 +3,6 @@ package v1
 import (
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -88,69 +87,9 @@ func (cr *OpenLibertyPerformanceData) GetInterval() int {
 	return getIntValueOrDefault(cr.Spec.Interval, defaultInterval)
 }
 
-// GetType returns status condition type
-func (c *OperationStatusCondition) GetType() OperationStatusConditionType {
-	return c.Type
-}
-
-// SetType sets status condition type
-func (c *OperationStatusCondition) SetType(ct OperationStatusConditionType) {
-	c.Type = ct
-}
-
-// GetLastTransitionTime return time of last status change
-func (c *OperationStatusCondition) GetLastTransitionTime() *metav1.Time {
-	return c.LastTransitionTime
-}
-
-// SetLastTransitionTime sets time of last status change
-func (c *OperationStatusCondition) SetLastTransitionTime(t *metav1.Time) {
-	c.LastTransitionTime = t
-}
-
-// GetLastUpdateTime return time of last status update
-func (c *OperationStatusCondition) GetLastUpdateTime() metav1.Time {
-	return c.LastUpdateTime
-}
-
-// SetLastUpdateTime sets time of last status update
-func (c *OperationStatusCondition) SetLastUpdateTime(t metav1.Time) {
-	c.LastUpdateTime = t
-}
-
-// GetMessage return condition's message
-func (c *OperationStatusCondition) GetMessage() string {
-	return c.Message
-}
-
-// SetMessage sets condition's message
-func (c *OperationStatusCondition) SetMessage(m string) {
-	c.Message = m
-}
-
-// GetReason return condition's message
-func (c *OperationStatusCondition) GetReason() string {
-	return c.Reason
-}
-
-// SetReason sets condition's reason
-func (c *OperationStatusCondition) SetReason(r string) {
-	c.Reason = r
-}
-
 // GetStatus return condition's status
 func (cr *OpenLibertyPerformanceData) GetStatus() *OpenLibertyPerformanceDataStatus {
 	return &cr.Status
-}
-
-// GetStatus return condition's status
-func (c *OperationStatusCondition) GetStatus() corev1.ConditionStatus {
-	return c.Status
-}
-
-// SetStatus sets condition's status
-func (c *OperationStatusCondition) SetStatus(s corev1.ConditionStatus) {
-	c.Status = s
 }
 
 // NewCondition returns new condition

--- a/internal/controller/assets/helper/linperf.sh
+++ b/internal/controller/assets/helper/linperf.sh
@@ -175,6 +175,16 @@ elif [ $ROOT_ACCESS_REQUIRED -eq 0 ]; then
   echo $(date '+%Y-%m-%d %H:%M:%S') "\tWarning: Root access is disabled. Data may be incomplete."
 fi
 
+############################
+# Create serviceability link
+############################
+if ! test -L /liberty/logs; then
+  SERVICEABILITY_FOLDER="/serviceability/$SERVICEABILITY_NAMESPACE/$HOSTNAME/logs"
+  mkdir -p $SERVICEABILITY_FOLDER
+  rm -rf /liberty/logs
+  ln -s $SERVICEABILITY_FOLDER /liberty/logs
+fi
+
 ################################
 # Assign OUTPUT_DIR and DIR_NAME 
 ################################

--- a/internal/controller/assets/helper/linperf.sh
+++ b/internal/controller/assets/helper/linperf.sh
@@ -179,10 +179,14 @@ fi
 # Create serviceability link
 ############################
 if ! test -L /liberty/logs; then
-  SERVICEABILITY_FOLDER="/serviceability/$SERVICEABILITY_NAMESPACE/$HOSTNAME/logs"
-  mkdir -p $SERVICEABILITY_FOLDER
-  rm -rf /liberty/logs
-  ln -s $SERVICEABILITY_FOLDER /liberty/logs
+  if [[ ! -z "$SERVICEABILITY_NAMESPACE" ]] && [[ ! -z $HOSTNAME ]]; then
+    SERVICEABILITY_FOLDER="/serviceability/$SERVICEABILITY_NAMESPACE/$HOSTNAME/logs"
+    mkdir -p $SERVICEABILITY_FOLDER
+    rm -rf /liberty/logs
+    ln -s $SERVICEABILITY_FOLDER /liberty/logs
+  else
+    ln -s /serviceability /liberty/logs
+  fi
 fi
 
 ################################

--- a/internal/controller/openlibertyperformancedata_controller.go
+++ b/internal/controller/openlibertyperformancedata_controller.go
@@ -205,7 +205,8 @@ func (r *ReconcileOpenLibertyPerformanceData) Reconcile(ctx context.Context, req
 		r.PodInjectorClient.SetMaxWorkers("linperf", pod.Name, pod.Namespace, maxWorkers)
 	}
 
-	injectorStatus := r.PodInjectorClient.PollStatus("linperf", pod.Name, pod.Namespace, utils.EncodeLinperfAttr(instance))
+	encodedAttrs := utils.EncodeLinperfAttr(instance)
+	injectorStatus := r.PodInjectorClient.PollStatus("linperf", pod.Name, pod.Namespace, encodedAttrs)
 	if injectorStatus != "done..." {
 		// exit on error
 		if strings.HasPrefix(injectorStatus, "error:") {

--- a/internal/controller/openlibertytrace_controller.go
+++ b/internal/controller/openlibertytrace_controller.go
@@ -133,7 +133,7 @@ func (r *ReconcileOpenLibertyTrace) Reconcile(ctx context.Context, request ctrl.
 		}
 		r.UpdateStatus(nil, openlibertyv1.OperationStatusConditionTypeEnabled, *instance, corev1.ConditionFalse, podName, podChanged)
 	} else {
-		traceOutputDir := serviceabilityDir + "/" + podNamespace + "/" + podName + "/logs" + 
+		traceOutputDir := serviceabilityDir + "/" + podNamespace + "/" + podName + "/logs"
 		traceConfig := "<server><logging traceSpecification=\"" + instance.Spec.TraceSpecification + "\" logDirectory=\"" + traceOutputDir + "\""
 		if instance.Spec.MaxFileSize != nil {
 			traceConfig += " maxFileSize=\"" + strconv.Itoa(int(*instance.Spec.MaxFileSize)) + "\""

--- a/internal/controller/openlibertytrace_controller.go
+++ b/internal/controller/openlibertytrace_controller.go
@@ -133,7 +133,7 @@ func (r *ReconcileOpenLibertyTrace) Reconcile(ctx context.Context, request ctrl.
 		}
 		r.UpdateStatus(nil, openlibertyv1.OperationStatusConditionTypeEnabled, *instance, corev1.ConditionFalse, podName, podChanged)
 	} else {
-		traceOutputDir := serviceabilityDir + "/" + podNamespace + "/" + podName
+		traceOutputDir := serviceabilityDir + "/" + podNamespace + "/" + podName + "/logs" + 
 		traceConfig := "<server><logging traceSpecification=\"" + instance.Spec.TraceSpecification + "\" logDirectory=\"" + traceOutputDir + "\""
 		if instance.Spec.MaxFileSize != nil {
 			traceConfig += " maxFileSize=\"" + strconv.Itoa(int(*instance.Spec.MaxFileSize)) + "\""

--- a/utils/socket/linperf.go
+++ b/utils/socket/linperf.go
@@ -25,7 +25,7 @@ func cpMakeTar(srcPath, destPath string, writer io.Writer) error
 func CopyAndRunLinperf(restConfig *rest.Config, podName string, podNamespace string, encodedAttrs string, doneCallback func(string, string, error)) (*io.PipeReader, *io.PipeWriter, context.CancelFunc, error) {
 	containerName := "app"
 	sourceFolder := "internal/controller/assets/helper"
-	destFolder := "$WLP_OUTPUT_DIR/helper"
+	destFolder := "/output/helper"
 	linperfCmd := utils.GetLinperfCmd(encodedAttrs, podName, podNamespace)
 	return CopyFolderToPodAndRunScript(restConfig, sourceFolder, destFolder, podName, podNamespace, containerName, linperfCmd, doneCallback)
 }

--- a/utils/socket/linperf.go
+++ b/utils/socket/linperf.go
@@ -116,7 +116,7 @@ func CopyFolderToPodAndRunScript(config *rest.Config, srcFolder string, destFold
 		})
 		if err != nil {
 			if strings.HasSuffix(fmt.Sprintf("%v", err), "exit code 129") {
-				err = fmt.Errorf("The pod's OpenLibertyApplication must enable .spec.serviceability in order to gather performance data")
+				err = fmt.Errorf("The Liberty custom resource which created this pod must enable .spec.serviceability in order to gather performance data")
 			} else if strings.HasSuffix(fmt.Sprintf("%v", err), "exit code 130") {
 				err = fmt.Errorf("The Liberty container is missing packages required for collecting performance data; To install the packages, include the command 'RUN command -v yum && pkgcmd=yum || pkgcmd=microdnf && ($pkgcmd update -y && $pkgcmd install -y procps-ng net-tools ncurses hostname)' in the Liberty container image definition")
 			} else {

--- a/utils/socket/linperf.go
+++ b/utils/socket/linperf.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"path"
 	"strings"
 
@@ -89,15 +88,16 @@ func CopyFolderToPodAndRunScript(config *rest.Config, srcFolder string, destFold
 			doneCallback("", "", wrappedErr)
 			return
 		}
+		var stdout, stderr bytes.Buffer
 		err = exec.StreamWithContext(streamContext, remotecommand.StreamOptions{
 			Stdin:  reader,
-			Stdout: os.Stdout,
-			Stderr: os.Stderr,
+			Stdout: &stdout,
+			Stderr: &stderr,
 			Tty:    false,
 		})
 		if err != nil {
 			wrappedErr := fmt.Errorf("Failed to create primary StreamWithContext: %v", err)
-			doneCallback("", "", wrappedErr)
+			doneCallback(stdout.String(), stderr.String(), wrappedErr)
 			return
 		}
 
@@ -108,7 +108,7 @@ func CopyFolderToPodAndRunScript(config *rest.Config, srcFolder string, destFold
 			doneCallback("", "", wrappedErr)
 			return
 		}
-		var stdout, stderr bytes.Buffer
+		stdout, stderr = bytes.Buffer{}, bytes.Buffer{}
 		err = exec.StreamWithContext(streamContext, remotecommand.StreamOptions{
 			Stdout: &stdout,
 			Stderr: &stderr,

--- a/utils/socket/linperf.go
+++ b/utils/socket/linperf.go
@@ -78,11 +78,12 @@ func CopyFolderToPodAndRunScript(config *rest.Config, srcFolder string, destFold
 	if len(destDir) > 0 {
 		command = append(command, "-C", destDir)
 	}
+	tarCmd := strings.Join(command, utils.FlagDelimiterSpace)
 
 	streamContext, cancelStreamContext := context.WithCancel(context.TODO())
 	go func() {
 		usingStdin := true
-		exec, err := remotecommand.NewSPDYExecutor(config, "POST", podExec(clientset, podName, podNamespace, containerName, usingStdin, command).URL())
+		exec, err := remotecommand.NewSPDYExecutor(config, "POST", podExec(clientset, podName, podNamespace, containerName, usingStdin, []string{"/bin/sh", "-c", tarCmd}).URL())
 		if err != nil {
 			wrappedErr := fmt.Errorf("Failed to create primary SPDY Executor: %v", err)
 			doneCallback("", "", wrappedErr)

--- a/utils/socket/linperf.go
+++ b/utils/socket/linperf.go
@@ -24,7 +24,7 @@ func cpMakeTar(srcPath, destPath string, writer io.Writer) error
 func CopyAndRunLinperf(restConfig *rest.Config, podName string, podNamespace string, encodedAttrs string, doneCallback func(string, string, error)) (*io.PipeReader, *io.PipeWriter, context.CancelFunc, error) {
 	containerName := "app"
 	sourceFolder := "internal/controller/assets/helper"
-	destFolder := "/output/helper"
+	destFolder := "$WLP_OUTPUT_DIR/helper"
 	linperfCmd := utils.GetLinperfCmd(encodedAttrs, podName, podNamespace)
 	return CopyFolderToPodAndRunScript(restConfig, sourceFolder, destFolder, podName, podNamespace, containerName, linperfCmd, doneCallback)
 }

--- a/utils/socket/linperf.go
+++ b/utils/socket/linperf.go
@@ -94,9 +94,17 @@ func CopyFolderToPodAndRunScript(config *rest.Config, srcFolder string, destFold
 			Stderr: os.Stderr,
 			Tty:    false,
 		})
+		if err != nil {
+			doneCallback("", "", err)
+			return
+		}
 
 		usingStdin = false
 		exec, err = remotecommand.NewSPDYExecutor(config, "POST", podExec(clientset, podName, podNamespace, containerName, usingStdin, []string{"/bin/sh", "-c", scriptCmd}).URL())
+		if err != nil {
+			doneCallback("", "", err)
+			return
+		}
 		var stdout, stderr bytes.Buffer
 		err = exec.StreamWithContext(streamContext, remotecommand.StreamOptions{
 			Stdout: &stdout,

--- a/utils/socket/linperf.go
+++ b/utils/socket/linperf.go
@@ -25,7 +25,7 @@ func cpMakeTar(srcPath, destPath string, writer io.Writer) error
 func CopyAndRunLinperf(restConfig *rest.Config, podName string, podNamespace string, encodedAttrs string, doneCallback func(string, string, error)) (*io.PipeReader, *io.PipeWriter, context.CancelFunc, error) {
 	containerName := "app"
 	sourceFolder := "internal/controller/assets/helper"
-	destFolder := "/output/helper"
+	destFolder := "$WLP_OUTPUT_DIR/helper"
 	linperfCmd := utils.GetLinperfCmd(encodedAttrs, podName, podNamespace)
 	return CopyFolderToPodAndRunScript(restConfig, sourceFolder, destFolder, podName, podNamespace, containerName, linperfCmd, doneCallback)
 }

--- a/utils/socket/linperf.go
+++ b/utils/socket/linperf.go
@@ -115,7 +115,13 @@ func CopyFolderToPodAndRunScript(config *rest.Config, srcFolder string, destFold
 			Tty:    false,
 		})
 		if err != nil {
-			err = fmt.Errorf("Failed to create secondary StreamWithContext: %v", err)
+			if strings.HasSuffix(fmt.Sprintf("%v", err), "exit code 129") {
+				err = fmt.Errorf("The pod's OpenLibertyApplication must enable .spec.serviceability in order to gather performance data")
+			} else if strings.HasSuffix(fmt.Sprintf("%v", err), "exit code 130") {
+				err = fmt.Errorf("The Liberty container is missing packages required for collecting performance data; To install the packages, include the command 'RUN command -v yum && pkgcmd=yum || pkgcmd=microdnf && ($pkgcmd update -y && $pkgcmd install -y procps-ng net-tools ncurses hostname)' in the Liberty container image definition")
+			} else {
+				err = fmt.Errorf("Failed to create secondary StreamWithContext: %v", err)
+			}
 		}
 		doneCallback(stdout.String(), stderr.String(), err)
 	}()

--- a/utils/socket/linperf.go
+++ b/utils/socket/linperf.go
@@ -114,8 +114,10 @@ func CopyFolderToPodAndRunScript(config *rest.Config, srcFolder string, destFold
 			Stderr: &stderr,
 			Tty:    false,
 		})
-		wrappedErr := fmt.Errorf("Failed to create secondary StreamWithContext: %v", err)
-		doneCallback(stdout.String(), stderr.String(), wrappedErr)
+		if err != nil {
+			err = fmt.Errorf("Failed to create secondary StreamWithContext: %v", err)
+		}
+		doneCallback(stdout.String(), stderr.String(), err)
 	}()
 	return reader, writer, cancelStreamContext, nil
 }

--- a/utils/socket/linperf_test.go
+++ b/utils/socket/linperf_test.go
@@ -3,10 +3,11 @@ package socket
 import "testing"
 
 func Test_getLinperfDataFileName(t *testing.T) {
-	outputFile := getLinperfDataFileName(`2025-07-23 13:34:54 \tTemporary directory linperf_RESULTS_sample.20250723.133044 removed.
+	outputFile := getLinperfDataFileName(`2025-07-23 13:34:54 Compressing the following files into linperf_RESULTS_sample.20250723.133044.tar.gz.
+2025-07-23 13:34:54 \tTemporary directory linperf_RESULTS_sample.20250723.133044 removed.
 2025-07-23 13:34:54 \tlinperf script complete.
 To share with IBM support, upload all the following files:
-* /serviceability/olo-test/example-75dfd65979-mwvnz/performanceData/linperf_RESULTS_sample.20250723.133044.tar.gz
+* /serviceability/olo-test/example-75dfd65979-mwvnz/performanceData/linperf_RESULTS_sample.20250723.133044
 * /var/log/messages (Linux OS files)
 For WebSphere Application Server:
 * Logs (systemout.log, native_stderr.log, etc)
@@ -16,6 +17,16 @@ For Liberty:
 * server.env, server.xml, and jvm.options`)
 	tests := []Test{
 		{"capture output file", "/serviceability/olo-test/example-75dfd65979-mwvnz/performanceData/linperf_RESULTS_sample.20250723.133044.tar.gz", outputFile},
+	}
+	if err := verifyTests(tests); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func Test_getSubstring(t *testing.T) {
+	substr1 := `hello world`
+	tests := []Test{
+		{"check substring 1", " wo", getSubstring([]string{substr1}, "ello", "wo")},
 	}
 	if err := verifyTests(tests); err != nil {
 		t.Fatalf("%v", err)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -38,6 +38,7 @@ var log = logf.Log.WithName("openliberty_utils")
 
 // Constant Values
 const serviceabilityMountPath = "/serviceability"
+const serviceabilityPodMountPath = "/liberty/logs"
 const ssoEnvVarPrefix = "SEC_SSO_"
 const OperandVersion = "1.5.0"
 
@@ -300,9 +301,9 @@ func CustomizeLibertyEnv(pts *corev1.PodTemplateSpec, la *olv1.OpenLibertyApplic
 
 	if la.GetServiceability() != nil {
 		targetEnv = append(targetEnv,
-			corev1.EnvVar{Name: "IBM_HEAPDUMPDIR", Value: serviceabilityMountPath},
-			corev1.EnvVar{Name: "IBM_COREDIR", Value: serviceabilityMountPath},
-			corev1.EnvVar{Name: "IBM_JAVACOREDIR", Value: serviceabilityMountPath},
+			corev1.EnvVar{Name: "IBM_HEAPDUMPDIR", Value: serviceabilityPodMountPath},
+			corev1.EnvVar{Name: "IBM_COREDIR", Value: serviceabilityPodMountPath},
+			corev1.EnvVar{Name: "IBM_JAVACOREDIR", Value: serviceabilityPodMountPath},
 		)
 	}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -235,7 +235,7 @@ func GetLinperfCmd(encodedAttrs, podName, podNamespace string) string {
 	linperfCmd := strings.Join(linperfCmdArgs, FlagDelimiterSpace)
 
 	// linperfCmdWithPids := fmt.Sprintf("mkdir -p %s && PIDS=$(ls -l /proc/[0-9]*/exe | grep \"/java$\" | xargs -L 1 | cut -d ' ' -f9 | cut -d '/' -f 3 ) && PIDS_OUT=$(echo $PIDS | tr '\n' ' ') && ls -l /proc/[0-9]*/exe > /serviceability/%s/%s/test.out && %s \"1\"", outputDir, podNamespace, podName, linperfCmd)
-	linperfCmdWithPids := fmt.Sprintf("if [[ $(df | grep /serviceability -c) -gt 0 ]]; then echo 'exit 129'; exit 129; fi && mkdir -p %s &&  %s \"1\"", serviceabilityRootDir, outputDir, linperfCmd)
+	linperfCmdWithPids := fmt.Sprintf("if [[ $(df | grep /serviceability -c) -gt 0 ]]; then echo 'exit 129'; return; fi && mkdir -p %s &&  %s \"1\"", serviceabilityRootDir, outputDir, linperfCmd)
 	return linperfCmdWithPids
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -236,6 +236,7 @@ func GetLinperfCmd(encodedAttrs, podName, podNamespace string) string {
 
 	// linperfCmdWithPids := fmt.Sprintf("mkdir -p %s && PIDS=$(ls -l /proc/[0-9]*/exe | grep \"/java$\" | xargs -L 1 | cut -d ' ' -f9 | cut -d '/' -f 3 ) && PIDS_OUT=$(echo $PIDS | tr '\n' ' ') && ls -l /proc/[0-9]*/exe > /serviceability/%s/%s/test.out && %s \"1\"", outputDir, podNamespace, podName, linperfCmd)
 	linperfCmdWithPids := fmt.Sprintf("if [ $(df | grep /serviceability -c) -gt 0 ]; then echo 'exit 129'; else mkdir -p %s &&  %s \"1\"; fi", serviceabilityRootDir, outputDir, linperfCmd)
+	fmt.Println("Linperf cmd: " + linperfCmdWithPids)
 	return linperfCmdWithPids
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -235,7 +235,7 @@ func GetLinperfCmd(encodedAttrs, podName, podNamespace string) string {
 	linperfCmd := strings.Join(linperfCmdArgs, FlagDelimiterSpace)
 
 	// linperfCmdWithPids := fmt.Sprintf("mkdir -p %s && PIDS=$(ls -l /proc/[0-9]*/exe | grep \"/java$\" | xargs -L 1 | cut -d ' ' -f9 | cut -d '/' -f 3 ) && PIDS_OUT=$(echo $PIDS | tr '\n' ' ') && ls -l /proc/[0-9]*/exe > /serviceability/%s/%s/test.out && %s \"1\"", outputDir, podNamespace, podName, linperfCmd)
-	linperfCmdWithPids := fmt.Sprintf("if [ $(df | grep %s -c) -gt 0 ]; then echo 'exit 129'; else mkdir -p %s && %s \"1\"; fi", serviceabilityRootDir, outputDir, linperfCmd)
+	linperfCmdWithPids := fmt.Sprintf("if [ $(df | grep %s -c) -gt 0 ]; then exit 129; else mkdir -p %s && %s \"1\"; fi", serviceabilityRootDir, outputDir, linperfCmd)
 	fmt.Println("Linperf cmd: " + linperfCmdWithPids)
 	return linperfCmdWithPids
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -235,7 +235,7 @@ func GetLinperfCmd(encodedAttrs, podName, podNamespace string) string {
 	linperfCmd := strings.Join(linperfCmdArgs, FlagDelimiterSpace)
 
 	// linperfCmdWithPids := fmt.Sprintf("mkdir -p %s && PIDS=$(ls -l /proc/[0-9]*/exe | grep \"/java$\" | xargs -L 1 | cut -d ' ' -f9 | cut -d '/' -f 3 ) && PIDS_OUT=$(echo $PIDS | tr '\n' ' ') && ls -l /proc/[0-9]*/exe > /serviceability/%s/%s/test.out && %s \"1\"", outputDir, podNamespace, podName, linperfCmd)
-	linperfCmdWithPids := fmt.Sprintf("if [[ $(df | grep /serviceability -c) -gt 0 ]]; then echo 'exit 129'; exit 0; fi && mkdir -p %s &&  %s \"1\"", serviceabilityRootDir, outputDir, linperfCmd)
+	linperfCmdWithPids := fmt.Sprintf("if [[ $(df | grep /serviceability -c) -gt 0 ]]; then echo 'exit 129'; else mkdir -p %s &&  %s \"1\" fi", serviceabilityRootDir, outputDir, linperfCmd)
 	return linperfCmdWithPids
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -235,7 +235,7 @@ func GetLinperfCmd(encodedAttrs, podName, podNamespace string) string {
 	linperfCmd := strings.Join(linperfCmdArgs, FlagDelimiterSpace)
 
 	// linperfCmdWithPids := fmt.Sprintf("mkdir -p %s && PIDS=$(ls -l /proc/[0-9]*/exe | grep \"/java$\" | xargs -L 1 | cut -d ' ' -f9 | cut -d '/' -f 3 ) && PIDS_OUT=$(echo $PIDS | tr '\n' ' ') && ls -l /proc/[0-9]*/exe > /serviceability/%s/%s/test.out && %s \"1\"", outputDir, podNamespace, podName, linperfCmd)
-	linperfCmdWithPids := fmt.Sprintf("if [[ $(df | grep /serviceability -c) -gt 0 ]]; then echo 'exit 129'; return; fi && mkdir -p %s &&  %s \"1\"", serviceabilityRootDir, outputDir, linperfCmd)
+	linperfCmdWithPids := fmt.Sprintf("if [[ $(df | grep /serviceability -c) -gt 0 ]]; then echo 'exit 129'; exit 0; fi && mkdir -p %s &&  %s \"1\"", serviceabilityRootDir, outputDir, linperfCmd)
 	return linperfCmdWithPids
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -235,7 +235,7 @@ func GetLinperfCmd(encodedAttrs, podName, podNamespace string) string {
 	linperfCmd := strings.Join(linperfCmdArgs, FlagDelimiterSpace)
 
 	// linperfCmdWithPids := fmt.Sprintf("mkdir -p %s && PIDS=$(ls -l /proc/[0-9]*/exe | grep \"/java$\" | xargs -L 1 | cut -d ' ' -f9 | cut -d '/' -f 3 ) && PIDS_OUT=$(echo $PIDS | tr '\n' ' ') && ls -l /proc/[0-9]*/exe > /serviceability/%s/%s/test.out && %s \"1\"", outputDir, podNamespace, podName, linperfCmd)
-	linperfCmdWithPids := fmt.Sprintf("if [ $(df | grep /serviceability -c) -gt 0 ]; then echo 'exit 129'; else mkdir -p %s &&  %s \"1\"; fi", serviceabilityRootDir, outputDir, linperfCmd)
+	linperfCmdWithPids := fmt.Sprintf("if [ $(df | grep %s -c) -gt 0 ]; then echo 'exit 129'; else mkdir -p %s && %s \"1\"; fi", serviceabilityRootDir, outputDir, linperfCmd)
 	fmt.Println("Linperf cmd: " + linperfCmdWithPids)
 	return linperfCmdWithPids
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -235,7 +235,7 @@ func GetLinperfCmd(encodedAttrs, podName, podNamespace string) string {
 	linperfCmd := strings.Join(linperfCmdArgs, FlagDelimiterSpace)
 
 	// linperfCmdWithPids := fmt.Sprintf("mkdir -p %s && PIDS=$(ls -l /proc/[0-9]*/exe | grep \"/java$\" | xargs -L 1 | cut -d ' ' -f9 | cut -d '/' -f 3 ) && PIDS_OUT=$(echo $PIDS | tr '\n' ' ') && ls -l /proc/[0-9]*/exe > /serviceability/%s/%s/test.out && %s \"1\"", outputDir, podNamespace, podName, linperfCmd)
-	linperfCmdWithPids := fmt.Sprintf("if [[ $(df | grep /serviceability -c) -gt 0 ]]; then exit 129; fi && mkdir -p %s &&  %s \"1\"", serviceabilityRootDir, outputDir, linperfCmd)
+	linperfCmdWithPids := fmt.Sprintf("if [[ $(df | grep /serviceability -c) -gt 0 ]]; then echo 'exit 129'; exit 129; fi && mkdir -p %s &&  %s \"1\"", serviceabilityRootDir, outputDir, linperfCmd)
 	return linperfCmdWithPids
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -212,7 +212,7 @@ func GetPerformanceDataWritingMessage(podName string) string {
 }
 
 func GetLinperfCmd(encodedAttrs, podName, podNamespace string) string {
-	scriptDir := "/output/helper"
+	scriptDir := "$WLP_OUTPUT_DIR/helper"
 	scriptName := "linperf.sh"
 
 	decodedLinperfAttrs := DecodeLinperfAttr(encodedAttrs)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -234,7 +234,6 @@ func GetLinperfCmd(encodedAttrs, podName, podNamespace string) string {
 	linperfCmdArgs = append(linperfCmdArgs, "--ignore-root")
 	linperfCmd := strings.Join(linperfCmdArgs, FlagDelimiterSpace)
 
-	// linperfCmdWithPids := fmt.Sprintf("mkdir -p %s && PIDS=$(ls -l /proc/[0-9]*/exe | grep \"/java$\" | xargs -L 1 | cut -d ' ' -f9 | cut -d '/' -f 3 ) && PIDS_OUT=$(echo $PIDS | tr '\n' ' ') && ls -l /proc/[0-9]*/exe > /serviceability/%s/%s/test.out && %s \"1\"", outputDir, podNamespace, podName, linperfCmd)
 	requiredPackages := []string{"procps-ng", "net-tools", "ncurses", "hostname"}
 	cmdArgs := []string{}
 	for _, pkg := range requiredPackages {
@@ -242,7 +241,8 @@ func GetLinperfCmd(encodedAttrs, podName, podNamespace string) string {
 	}
 	checkPackagesCmd := strings.Join(cmdArgs, "&&")
 
-	linperfCmdWithPids := fmt.Sprintf("if ! (command -v yum && pkgcmd=yum || pkgcmd=microdnf && %s); then exit 130; elif [ $(df | grep %s -c) -gt 0 ]; then exit 129; else mkdir -p %s && %s \"1\"; fi", checkPackagesCmd, serviceabilityRootDir, outputDir, linperfCmd)
+	// linperfCmdWithPids := fmt.Sprintf("mkdir -p %s && PIDS=$(ls -l /proc/[0-9]*/exe | grep \"/java$\" | xargs -L 1 | cut -d ' ' -f9 | cut -d '/' -f 3 ) && PIDS_OUT=$(echo $PIDS | tr '\n' ' ') && ls -l /proc/[0-9]*/exe > /serviceability/%s/%s/test.out && %s \"1\"", outputDir, podNamespace, podName, linperfCmd)
+	linperfCmdWithPids := fmt.Sprintf("if ! (command -v yum && pkgcmd=yum || pkgcmd=microdnf && %s); then exit 130; elif [ $(df | grep %s -c) -eq 0 ]; then exit 129; else mkdir -p %s && %s \"1\"; fi", checkPackagesCmd, serviceabilityRootDir, outputDir, linperfCmd)
 	fmt.Println("Linperf cmd: " + linperfCmdWithPids)
 	return linperfCmdWithPids
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -235,7 +235,7 @@ func GetLinperfCmd(encodedAttrs, podName, podNamespace string) string {
 	linperfCmd := strings.Join(linperfCmdArgs, FlagDelimiterSpace)
 
 	// linperfCmdWithPids := fmt.Sprintf("mkdir -p %s && PIDS=$(ls -l /proc/[0-9]*/exe | grep \"/java$\" | xargs -L 1 | cut -d ' ' -f9 | cut -d '/' -f 3 ) && PIDS_OUT=$(echo $PIDS | tr '\n' ' ') && ls -l /proc/[0-9]*/exe > /serviceability/%s/%s/test.out && %s \"1\"", outputDir, podNamespace, podName, linperfCmd)
-	linperfCmdWithPids := fmt.Sprintf("if [[ $(df | grep /serviceability -c) -gt 0 ]]; then echo 'exit 129'; else mkdir -p %s &&  %s \"1\"; fi", serviceabilityRootDir, outputDir, linperfCmd)
+	linperfCmdWithPids := fmt.Sprintf("if [ $(df | grep /serviceability -c) -gt 0 ]; then echo 'exit 129'; else mkdir -p %s &&  %s \"1\"; fi", serviceabilityRootDir, outputDir, linperfCmd)
 	return linperfCmdWithPids
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -235,7 +235,7 @@ func GetLinperfCmd(encodedAttrs, podName, podNamespace string) string {
 	linperfCmd := strings.Join(linperfCmdArgs, FlagDelimiterSpace)
 
 	// linperfCmdWithPids := fmt.Sprintf("mkdir -p %s && PIDS=$(ls -l /proc/[0-9]*/exe | grep \"/java$\" | xargs -L 1 | cut -d ' ' -f9 | cut -d '/' -f 3 ) && PIDS_OUT=$(echo $PIDS | tr '\n' ' ') && ls -l /proc/[0-9]*/exe > /serviceability/%s/%s/test.out && %s \"1\"", outputDir, podNamespace, podName, linperfCmd)
-	linperfCmdWithPids := fmt.Sprintf("if test -w %s; then exit 1 fi && mkdir -p %s &&  %s \"1\"", serviceabilityRootDir, outputDir, linperfCmd)
+	linperfCmdWithPids := fmt.Sprintf("if [[ $(df | grep /serviceability -c) -gt 0 ]]; then exit 129; fi && mkdir -p %s &&  %s \"1\"", serviceabilityRootDir, outputDir, linperfCmd)
 	return linperfCmdWithPids
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -212,7 +212,7 @@ func GetPerformanceDataWritingMessage(podName string) string {
 }
 
 func GetLinperfCmd(encodedAttrs, podName, podNamespace string) string {
-	scriptDir := "$WLP_OUTPUT_DIR/helper"
+	scriptDir := "/output/helper"
 	scriptName := "linperf.sh"
 
 	decodedLinperfAttrs := DecodeLinperfAttr(encodedAttrs)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -212,13 +212,14 @@ func GetPerformanceDataWritingMessage(podName string) string {
 }
 
 func GetLinperfCmd(encodedAttrs, podName, podNamespace string) string {
-	scriptDir := "/output/helper"
+	scriptDir := "$WLP_OUTPUT_DIR/helper"
 	scriptName := "linperf.sh"
 
 	decodedLinperfAttrs := DecodeLinperfAttr(encodedAttrs)
 
 	linperfCmdArgs := []string{fmt.Sprintf("%s/%s", scriptDir, scriptName)}
-	outputDir := fmt.Sprintf("/serviceability/%s/%s/performanceData/", podNamespace, podName)
+	serviceabilityRootDir := "/serviceability"
+	outputDir := fmt.Sprintf("%s/%s/%s/performanceData/", serviceabilityRootDir, podNamespace, podName)
 	linperfCmdArgs = append(linperfCmdArgs, parseFlag("--output-dir", outputDir, FlagDelimiterEquals))
 
 	now := time.Now()
@@ -234,7 +235,7 @@ func GetLinperfCmd(encodedAttrs, podName, podNamespace string) string {
 	linperfCmd := strings.Join(linperfCmdArgs, FlagDelimiterSpace)
 
 	// linperfCmdWithPids := fmt.Sprintf("mkdir -p %s && PIDS=$(ls -l /proc/[0-9]*/exe | grep \"/java$\" | xargs -L 1 | cut -d ' ' -f9 | cut -d '/' -f 3 ) && PIDS_OUT=$(echo $PIDS | tr '\n' ' ') && ls -l /proc/[0-9]*/exe > /serviceability/%s/%s/test.out && %s \"1\"", outputDir, podNamespace, podName, linperfCmd)
-	linperfCmdWithPids := fmt.Sprintf("mkdir -p %s &&  %s \"1\"", outputDir, linperfCmd)
+	linperfCmdWithPids := fmt.Sprintf("if test -w %s; then exit 1 fi && mkdir -p %s &&  %s \"1\"", serviceabilityRootDir, outputDir, linperfCmd)
 	return linperfCmdWithPids
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -239,11 +239,11 @@ func GetLinperfCmd(encodedAttrs, podName, podNamespace string) string {
 	for _, pkg := range requiredPackages {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("$pkgcmd list installed %s", pkg))
 	}
-	checkPackagesCmd := strings.Join(cmdArgs, "&&")
+	checkPackagesCmd := strings.Join(cmdArgs, " && ") // add spaces for readability
 
 	// linperfCmdWithPids := fmt.Sprintf("mkdir -p %s && PIDS=$(ls -l /proc/[0-9]*/exe | grep \"/java$\" | xargs -L 1 | cut -d ' ' -f9 | cut -d '/' -f 3 ) && PIDS_OUT=$(echo $PIDS | tr '\n' ' ') && ls -l /proc/[0-9]*/exe > /serviceability/%s/%s/test.out && %s \"1\"", outputDir, podNamespace, podName, linperfCmd)
 	linperfCmdWithPids := fmt.Sprintf("if ! (command -v yum && pkgcmd=yum || pkgcmd=microdnf && %s); then exit 130; elif [ $(df | grep %s -c) -eq 0 ]; then exit 129; else mkdir -p %s && %s \"1\"; fi", checkPackagesCmd, serviceabilityRootDir, outputDir, linperfCmd)
-	fmt.Println("Linperf cmd: " + linperfCmdWithPids)
+	// fmt.Println("Linperf cmd: " + linperfCmdWithPids) // un-commment this line for debugging
 	return linperfCmdWithPids
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -235,7 +235,7 @@ func GetLinperfCmd(encodedAttrs, podName, podNamespace string) string {
 	linperfCmd := strings.Join(linperfCmdArgs, FlagDelimiterSpace)
 
 	// linperfCmdWithPids := fmt.Sprintf("mkdir -p %s && PIDS=$(ls -l /proc/[0-9]*/exe | grep \"/java$\" | xargs -L 1 | cut -d ' ' -f9 | cut -d '/' -f 3 ) && PIDS_OUT=$(echo $PIDS | tr '\n' ' ') && ls -l /proc/[0-9]*/exe > /serviceability/%s/%s/test.out && %s \"1\"", outputDir, podNamespace, podName, linperfCmd)
-	linperfCmdWithPids := fmt.Sprintf("if [[ $(df | grep /serviceability -c) -gt 0 ]]; then echo 'exit 129'; else mkdir -p %s &&  %s \"1\" fi", serviceabilityRootDir, outputDir, linperfCmd)
+	linperfCmdWithPids := fmt.Sprintf("if [[ $(df | grep /serviceability -c) -gt 0 ]]; then echo 'exit 129'; else mkdir -p %s &&  %s \"1\"; fi", serviceabilityRootDir, outputDir, linperfCmd)
 	return linperfCmdWithPids
 }
 


### PR DESCRIPTION
**What this PR does / why we need it?**:

Fixes https://github.com/OpenLiberty/open-liberty-operator/issues/759
- Uses `$WLP_OUTPUT_DIR/helper` instead of `/output/helper` for copying `linperf.sh` into the pod
- Outputs error message when required `linperf.sh` packages are not installed in the Liberty container OS
- Outputs error message when `/serviceability` mount could not be found in the Liberty container
- Stops frequently using lastUpdatedTime and sets lastTransitionTime occasionally instead.
- Fixes issue with performance data file name not being parsed for long file paths
- Sets trace output dir from the `/serviceability/ns/pod` to the `/serviceability/ns/pod/logs` folder.

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
