### PR TITLE
Add trace .status.logDirectory and add serverDumps subfolder

### DIFF
--- a/api/v1/openlibertytrace_types.go
+++ b/api/v1/openlibertytrace_types.go
@@ -31,6 +31,9 @@ type OpenLibertyTraceStatus struct {
 	Conditions       []OperationStatusCondition `json:"conditions,omitempty"`
 	OperatedResource OperatedResource           `json:"operatedResource,omitempty"`
 	Versions         TraceStatusVersions        `json:"versions,omitempty"`
+	// Location of the trace log directory
+	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Log Directory",xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
+	LogDirectory string `json:"logDirectory,omitempty"`
 	// The generation identifier of this OpenLibertyTrace instance completely reconciled by the Operator.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }

--- a/bundle/manifests/apps.openliberty.io_openlibertytraces.yaml
+++ b/bundle/manifests/apps.openliberty.io_openlibertytraces.yaml
@@ -115,6 +115,9 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              logDirectory:
+                description: Location of the trace log directory
+                type: string
               observedGeneration:
                 description: The generation identifier of this OpenLibertyTrace instance
                   completely reconciled by the Operator.

--- a/bundle/manifests/open-liberty.clusterserviceversion.yaml
+++ b/bundle/manifests/open-liberty.clusterserviceversion.yaml
@@ -104,7 +104,7 @@ metadata:
     categories: Application Runtime
     certified: "true"
     containerImage: icr.io/appcafe/open-liberty-operator:daily
-    createdAt: "2025-08-26T21:10:21Z"
+    createdAt: "2025-09-05T18:45:10Z"
     description: Deploy and manage containerized Liberty applications
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -1087,6 +1087,12 @@ spec:
       displayName: OpenLibertyTrace
       kind: OpenLibertyTrace
       name: openlibertytraces.apps.openliberty.io
+      statusDescriptors:
+      - description: Location of the trace log directory
+        displayName: Log Directory
+        path: logDirectory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       version: v1
     - description: Day-2 operation for gathering server traces
       displayName: OpenLibertyTrace

--- a/config/crd/bases/apps.openliberty.io_openlibertytraces.yaml
+++ b/config/crd/bases/apps.openliberty.io_openlibertytraces.yaml
@@ -111,6 +111,9 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              logDirectory:
+                description: Location of the trace log directory
+                type: string
               observedGeneration:
                 description: The generation identifier of this OpenLibertyTrace instance
                   completely reconciled by the Operator.

--- a/config/manifests/bases/open-liberty.clusterserviceversion.yaml
+++ b/config/manifests/bases/open-liberty.clusterserviceversion.yaml
@@ -911,6 +911,12 @@ spec:
       displayName: OpenLibertyTrace
       kind: OpenLibertyTrace
       name: openlibertytraces.apps.openliberty.io
+      statusDescriptors:
+      - description: Location of the trace log directory
+        displayName: Log Directory
+        path: logDirectory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       version: v1
     - description: Day-2 operation for gathering server traces
       displayName: OpenLibertyTrace

--- a/internal/controller/openlibertydump_controller.go
+++ b/internal/controller/openlibertydump_controller.go
@@ -92,7 +92,7 @@ func (r *ReconcileOpenLibertyDump) Reconcile(ctx context.Context, request ctrl.R
 	}
 
 	currentTime := time.Now()
-	dumpFolder := "/serviceability/" + pod.Namespace + "/" + pod.Name
+	dumpFolder := "/serviceability/" + pod.Namespace + "/" + pod.Name + "/serverDumps"
 	dumpFileName := dumpFolder + "/" + "dump_" + currentTime.UTC().Format("2006.01.02_15.04.05") + "_utc.zip"
 	dumpCmd := "mkdir -p " + dumpFolder + " &&  server dump --archive=" + dumpFileName
 	if len(instance.Spec.Include) > 0 {

--- a/internal/deploy/kubectl/openliberty-app-crd.yaml
+++ b/internal/deploy/kubectl/openliberty-app-crd.yaml
@@ -18412,6 +18412,9 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              logDirectory:
+                description: Location of the trace log directory
+                type: string
               observedGeneration:
                 description: The generation identifier of this OpenLibertyTrace instance
                   completely reconciled by the Operator.

--- a/internal/deploy/kustomize/daily/base/open-liberty-crd.yaml
+++ b/internal/deploy/kustomize/daily/base/open-liberty-crd.yaml
@@ -18412,6 +18412,9 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              logDirectory:
+                description: Location of the trace log directory
+                type: string
               observedGeneration:
                 description: The generation identifier of this OpenLibertyTrace instance
                   completely reconciled by the Operator.


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Add field `.status.logDirectory` to the OpenLibertyTrace
- Append subfolder `serverDumps` to the `/serviceability/ns/pod/serverDumps` folder path for dump output

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
