### PR TITLE
Write Javacores to the /serviceability pod directory

### DIFF
--- a/internal/controller/assets/helper/linperf.sh
+++ b/internal/controller/assets/helper/linperf.sh
@@ -175,19 +175,6 @@ elif [ $ROOT_ACCESS_REQUIRED -eq 0 ]; then
   echo $(date '+%Y-%m-%d %H:%M:%S') "\tWarning: Root access is disabled. Data may be incomplete."
 fi
 
-############################
-# Create serviceability link
-############################
-if ! test -e /liberty/logs; then
-  if [[ ! -z "$SERVICEABILITY_NAMESPACE" ]] && [[ ! -z $HOSTNAME ]]; then
-    SERVICEABILITY_FOLDER="/serviceability/$SERVICEABILITY_NAMESPACE/$HOSTNAME/logs"
-    mkdir -p $SERVICEABILITY_FOLDER
-    ln -s $SERVICEABILITY_FOLDER /liberty/logs
-  else
-    ln -s /serviceability /liberty/logs
-  fi
-fi
-
 ################################
 # Assign OUTPUT_DIR and DIR_NAME 
 ################################

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -38,7 +38,6 @@ var log = logf.Log.WithName("openliberty_utils")
 
 // Constant Values
 const serviceabilityMountPath = "/serviceability"
-const serviceabilityPodMountPath = "/liberty/logs"
 const ssoEnvVarPrefix = "SEC_SSO_"
 const OperandVersion = "1.5.0"
 
@@ -300,10 +299,15 @@ func CustomizeLibertyEnv(pts *corev1.PodTemplateSpec, la *olv1.OpenLibertyApplic
 	}
 
 	if la.GetServiceability() != nil {
+		logDirMountPath := fmt.Sprintf("%s/%s/%s/logs", serviceabilityMountPath, la.GetNamespace(), "$(SERVICEABILITY_HOSTNAME)")
+		logDirEnvName := "LOG_DIR"
+		logDirEnvValue := fmt.Sprintf("$(%s)", logDirEnvName)
 		targetEnv = append(targetEnv,
-			corev1.EnvVar{Name: "IBM_HEAPDUMPDIR", Value: serviceabilityPodMountPath},
-			corev1.EnvVar{Name: "IBM_COREDIR", Value: serviceabilityPodMountPath},
-			corev1.EnvVar{Name: "IBM_JAVACOREDIR", Value: serviceabilityPodMountPath},
+			corev1.EnvVar{Name: "SERVICEABILITY_HOSTNAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}}},
+			corev1.EnvVar{Name: logDirEnvName, Value: logDirMountPath},
+			corev1.EnvVar{Name: "IBM_HEAPDUMPDIR", Value: logDirEnvValue},
+			corev1.EnvVar{Name: "IBM_COREDIR", Value: logDirEnvValue},
+			corev1.EnvVar{Name: "IBM_JAVACOREDIR", Value: logDirEnvValue},
 		)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it?**:

- When .spec.serviceability is enabled, `LOG_DIR` will be set to the /serviceability pod logs directory at `/serviceability/namespace/pod/logs` and directories for `IBM_HEAPDUMPDIR` `IBM_COREDIR` and `IBM_JAVACOREDIR` will be set to `LOG_DIR`.

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
