### PR TITLE
Ignore secrets baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ tags
 bin
 vendor
 liberty/**
+# To allow the file to be copied into this repo during a build
+olo.secrets.baseline


### PR DESCRIPTION
So that it can be copied into the source tree during a build

