### PR TITLE
Update ose-operator-registry to 4.20

### DIFF
--- a/catalog.Dockerfile
+++ b/catalog.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18 AS builder
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.20 AS builder
 FROM registry.redhat.io/ubi9/ubi-minimal
 
 # Add label for location of Declarative Config root directory & required OpenShift labels


### PR DESCRIPTION
**What this PR does / why we need it?**:

Updates ose-operator-registry-rhel9 to v4.20 in the catalog's dockerfile to fixes several issues found by the scans
Has been tested against v4.20, v4.18 and v4.16 of OCP
