### PR TITLE
Add OCP global pull secret in image version checks

### DIFF
--- a/internal/controller/openlibertyapplication_controller.go
+++ b/internal/controller/openlibertyapplication_controller.go
@@ -1151,7 +1151,7 @@ func (r *ReconcileOpenLiberty) getContainerImageMetadata(reqLogger logr.Logger, 
 		if err == nil {
 			olappSecrets = append(olappSecrets, *globalPullSecret)
 		} else if !kerrors.IsNotFound(err) {
-			return "", nil, fmt.Errorf("Failed to get the global OpenShift pull secret: %v", err)
+			return "", nil, fmt.Errorf("Failed to get the OpenShift global pull secret: %v", err)
 		}
 	}
 

--- a/internal/controller/openlibertyapplication_controller.go
+++ b/internal/controller/openlibertyapplication_controller.go
@@ -1140,7 +1140,7 @@ func (r *ReconcileOpenLiberty) deletePVC(reqLogger logr.Logger, pvcName string, 
 func (r *ReconcileOpenLiberty) getContainerImageMetadata(reqLogger logr.Logger, olapp *openlibertyv1.OpenLibertyApplication, imageRef imagev1.DockerImageReference) (string, *runtime.RawExtension, error) {
 	olappSecrets := []corev1.Secret{}
 
-	// check the OpenShift global pull secret for inclusion and allow errors if it doesn't exist
+	// check the OpenShift global pull secret for inclusion
 	if len(r.watchNamespaces) == 0 && r.IsOpenShift() {
 		globalPullSecretName := "pull-secret"
 		globalPullSecretNamespace := "openshift-config"
@@ -1150,6 +1150,8 @@ func (r *ReconcileOpenLiberty) getContainerImageMetadata(reqLogger logr.Logger, 
 		err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: globalPullSecretName, Namespace: globalPullSecretNamespace}, globalPullSecret)
 		if err == nil {
 			olappSecrets = append(olappSecrets, *globalPullSecret)
+		} else if !kerrors.IsNotFound(err) {
+			return "", nil, fmt.Errorf("Failed to get the global OpenShift pull secret: %v", err)
 		}
 	}
 

--- a/internal/controller/openlibertyapplication_controller.go
+++ b/internal/controller/openlibertyapplication_controller.go
@@ -1139,6 +1139,21 @@ func (r *ReconcileOpenLiberty) deletePVC(reqLogger logr.Logger, pvcName string, 
 
 func (r *ReconcileOpenLiberty) getContainerImageMetadata(reqLogger logr.Logger, olapp *openlibertyv1.OpenLibertyApplication, imageRef imagev1.DockerImageReference) (string, *runtime.RawExtension, error) {
 	olappSecrets := []corev1.Secret{}
+
+	// check the OpenShift global pull secret for inclusion and allow errors if it doesn't exist
+	if len(r.watchNamespaces) == 0 && r.IsOpenShift() {
+		globalPullSecretName := "pull-secret"
+		globalPullSecretNamespace := "openshift-config"
+		globalPullSecret := &corev1.Secret{}
+		globalPullSecret.Name = globalPullSecretName
+		globalPullSecret.Namespace = globalPullSecretNamespace
+		err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: globalPullSecretName, Namespace: globalPullSecretNamespace}, globalPullSecret)
+		if err == nil {
+			olappSecrets = append(olappSecrets, *globalPullSecret)
+		}
+	}
+
+	// check the CR-configured pull secrets
 	var pullSecret *corev1.Secret
 	if olapp.GetPullSecret() != nil {
 		pullSecretNames := oputils.DecodeStringToList(*olapp.GetPullSecret())

--- a/internal/controller/openlibertyapplication_controller.go
+++ b/internal/controller/openlibertyapplication_controller.go
@@ -1141,21 +1141,6 @@ func (r *ReconcileOpenLiberty) deletePVC(reqLogger logr.Logger, pvcName string, 
 func (r *ReconcileOpenLiberty) getContainerImageMetadata(reqLogger logr.Logger, olapp *openlibertyv1.OpenLibertyApplication, imageRef imagev1.DockerImageReference) (string, *runtime.RawExtension, error) {
 	olappSecrets := []corev1.Secret{}
 
-	// check the OpenShift global pull secret for inclusion
-	if r.isClusterWide && r.IsOpenShift() {
-		globalPullSecretName := "pull-secret"
-		globalPullSecretNamespace := "openshift-config"
-		globalPullSecret := &corev1.Secret{}
-		globalPullSecret.Name = globalPullSecretName
-		globalPullSecret.Namespace = globalPullSecretNamespace
-		err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: globalPullSecretName, Namespace: globalPullSecretNamespace}, globalPullSecret)
-		if err == nil {
-			olappSecrets = append(olappSecrets, *globalPullSecret)
-		} else if !kerrors.IsNotFound(err) {
-			return "", nil, fmt.Errorf("Failed to get the OpenShift global pull secret: %v", err)
-		}
-	}
-
 	// check the CR-configured pull secrets
 	var pullSecret *corev1.Secret
 	if olapp.GetPullSecret() != nil {
@@ -1174,6 +1159,21 @@ func (r *ReconcileOpenLiberty) getContainerImageMetadata(reqLogger logr.Logger, 
 			if pullSecret != nil {
 				olappSecrets = append(olappSecrets, *pullSecret)
 			}
+		}
+	}
+
+	// check the OpenShift global pull secret for inclusion
+	if r.isClusterWide && r.IsOpenShift() {
+		globalPullSecretName := "pull-secret"
+		globalPullSecretNamespace := "openshift-config"
+		globalPullSecret := &corev1.Secret{}
+		globalPullSecret.Name = globalPullSecretName
+		globalPullSecret.Namespace = globalPullSecretNamespace
+		err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: globalPullSecretName, Namespace: globalPullSecretNamespace}, globalPullSecret)
+		if err == nil {
+			olappSecrets = append(olappSecrets, *globalPullSecret)
+		} else if !kerrors.IsNotFound(err) {
+			return "", nil, fmt.Errorf("Failed to get the OpenShift global pull secret: %v", err)
 		}
 	}
 	return libertyimage.NewNamespaceCredentialsContext(reqLogger, olappSecrets, olapp.GetNamespace()).GetContainerImageMetadata(context.TODO(), imageRef, pullSecret, false)

--- a/internal/controller/openlibertyapplication_controller.go
+++ b/internal/controller/openlibertyapplication_controller.go
@@ -51,6 +51,7 @@ type ReconcileOpenLiberty struct {
 	oputils.ReconcilerBase
 	Log             logr.Logger
 	watchNamespaces []string
+	isClusterWide   bool
 }
 
 const applicationFinalizer = "finalizer.openlibertyapplications.apps.openliberty.io"
@@ -992,33 +993,33 @@ func (r *ReconcileOpenLiberty) SetupWithManager(mgr ctrl.Manager) error {
 	for _, ns := range watchNamespaces {
 		watchNamespacesMap[ns] = true
 	}
-	isClusterWide := oputils.IsClusterWide(watchNamespaces)
+	r.isClusterWide = oputils.IsClusterWide(watchNamespaces)
 
 	pred := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			// Ignore updates to CR status in which case metadata.Generation does not change
-			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() && (isClusterWide || watchNamespacesMap[e.ObjectNew.GetNamespace()])
+			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() && (r.isClusterWide || watchNamespacesMap[e.ObjectNew.GetNamespace()])
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
-			return isClusterWide || watchNamespacesMap[e.Object.GetNamespace()]
+			return r.isClusterWide || watchNamespacesMap[e.Object.GetNamespace()]
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return isClusterWide || watchNamespacesMap[e.Object.GetNamespace()]
+			return r.isClusterWide || watchNamespacesMap[e.Object.GetNamespace()]
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
-			return isClusterWide || watchNamespacesMap[e.Object.GetNamespace()]
+			return r.isClusterWide || watchNamespacesMap[e.Object.GetNamespace()]
 		},
 	}
 
 	predSubResource := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return (isClusterWide || watchNamespacesMap[e.ObjectOld.GetNamespace()])
+			return (r.isClusterWide || watchNamespacesMap[e.ObjectOld.GetNamespace()])
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
 			return false
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return isClusterWide || watchNamespacesMap[e.Object.GetNamespace()]
+			return r.isClusterWide || watchNamespacesMap[e.Object.GetNamespace()]
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
 			return false
@@ -1028,13 +1029,13 @@ func (r *ReconcileOpenLiberty) SetupWithManager(mgr ctrl.Manager) error {
 	predSubResWithGenCheck := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			// Ignore updates to CR status in which case metadata.Generation does not change
-			return (isClusterWide || watchNamespacesMap[e.ObjectOld.GetNamespace()]) && e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
+			return (r.isClusterWide || watchNamespacesMap[e.ObjectOld.GetNamespace()]) && e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
 			return false
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return isClusterWide || watchNamespacesMap[e.Object.GetNamespace()]
+			return r.isClusterWide || watchNamespacesMap[e.Object.GetNamespace()]
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
 			return false
@@ -1141,7 +1142,7 @@ func (r *ReconcileOpenLiberty) getContainerImageMetadata(reqLogger logr.Logger, 
 	olappSecrets := []corev1.Secret{}
 
 	// check the OpenShift global pull secret for inclusion
-	if len(r.watchNamespaces) == 0 && r.IsOpenShift() {
+	if r.isClusterWide && r.IsOpenShift() {
 		globalPullSecretName := "pull-secret"
 		globalPullSecretNamespace := "openshift-config"
 		globalPullSecret := &corev1.Secret{}


### PR DESCRIPTION
**What this PR does / why we need it?**:

- For Liberty version checks, the operator should check for a global pull secret (on OpenShift Container Platform) to use in validating Liberty image versions from private registries. 
- To resolve https://github.com/WASdev/websphere-liberty-operator/issues/847

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
