### PR TITLE
Revert Liberty version to 26.0.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM registry.access.redhat.com/ubi9-minimal:latest as builder
 ARG GO_PLATFORM=amd64
 ARG GO_VERSION_ARG
-ARG LIBERTY_VERSION=26.0.0.3
+ARG LIBERTY_VERSION=26.0.0.2
 ENV PATH=$PATH:/usr/local/go/bin
 RUN microdnf -y install tar gzip unzip
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= 1.6.1
 OPERATOR_SDK_RELEASE_VERSION ?= v1.42.0
-LIBERTY_VERSION ?= 26.0.0.3
+LIBERTY_VERSION ?= 26.0.0.2
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Revert to 26.0.0.2 to avoid LTPA regression on 26.0.0.3

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
